### PR TITLE
refactor: add CSS tokens and streamline hero fonts

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,0 +1,20 @@
+name: ci-screenshots
+
+on:
+  pull_request:
+
+jobs:
+  screenshots:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npm test
+      - uses: actions/upload-artifact@v4
+        with:
+          name: screenshots
+          path: screenshots

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+screenshots/

--- a/ROLLBACK.md
+++ b/ROLLBACK.md
@@ -1,0 +1,3 @@
+To rollback this feature set, run:
+
+  git revert 3a179f4

--- a/ci/screenshot.mjs
+++ b/ci/screenshot.mjs
@@ -1,0 +1,21 @@
+import {chromium} from 'playwright';
+import {mkdir} from 'fs/promises';
+import path from 'path';
+
+const viewports = [390, 1024, 1440];
+const url = 'file://' + path.resolve('index_team.html');
+
+await mkdir('screenshots', {recursive: true});
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+
+for (const width of viewports) {
+  await page.setViewportSize({width, height: 900});
+  await page.goto(url);
+  await page.screenshot({path: `screenshots/hero-${width}.png`});
+  await page.evaluate(() => window.scrollBy(0, window.innerHeight));
+  await page.screenshot({path: `screenshots/scroll-${width}.png`});
+}
+
+await browser.close();

--- a/css/hb_brand.css
+++ b/css/hb_brand.css
@@ -58,10 +58,7 @@
   animation: glassIn .6s ease
              calc(var(--heroDelay, .45s) + var(--heroDur, .60s) + .10s)
              both;                                /* sanftes Aufpoppen */
-  /* Wichtig: Website-Standardtypografie in B */
-  font-family: inherit;
 }
-#hero-section .hb-hero--split .hb-hero-B *{ font-family: inherit; }
 
 /* Fallback, falls kein backdrop-filter verfügbar */
 @supports not ((backdrop-filter: blur(0)) or (-webkit-backdrop-filter: blur(0))){

--- a/css/hb_brand.css
+++ b/css/hb_brand.css
@@ -100,7 +100,6 @@ background:
 
 #hero-section .hb-hero--split p.hb-glass-text{
   margin: 0 0 .8em 0;
- line-height: 1.2 ;
   line-height: 1.6;
   color: rgba(255,255,255,0.9);
   /* Mobil ≈ 1.2 rem → Desktop 1.5 rem */

--- a/css/hb_brand.css
+++ b/css/hb_brand.css
@@ -89,26 +89,25 @@ background:
    NEU  BLOCK – einfügen an derselben Stelle
    Typo in der Glasbox  |  Clean Build 1.3  |  21 Aug 2025
    • Headline & Body skalieren sauber per clamp()
-   • !important sichert Priorität ohne #justage
    ========================================================= */
 
-#hero-section .hb-hero--split .hb-glass-title h2{
+#hero-section .hb-hero--split h2.hb-glass-title{
   margin: 0 0 .4em 0;
 	line-height: 1.2 ;
   letter-spacing: .02em;
   text-transform: uppercase;
   color: var(--t2);
   /* Mobil ≈ 1.6 rem → Desktop 3 rem */
-  font-size: clamp(2.2rem, 4vw, 3rem) !important;
+  font-size: clamp(2.2rem, 4vw, 3rem);
 }
 
-#hero-section .hb-hero--split .hb-glass-text p{
+#hero-section .hb-hero--split p.hb-glass-text{
   margin: 0 0 .8em 0;
  line-height: 1.2 ;
   line-height: 1.6;
   color: rgba(255,255,255,0.9);
   /* Mobil ≈ 1.2 rem → Desktop 1.5 rem */
-  font-size: clamp(1.6rem, 4vw, 1.5rem) !important;
+  font-size: clamp(1.6rem, 4vw, 1.5rem);
 }
 
 /* ===== Ende Typo-Override Glasbox – Build 1.3 (21 Aug 2025) ===== */

--- a/css/hb_hero.css
+++ b/css/hb_hero.css
@@ -33,7 +33,7 @@
   height:min(100svh,700px);
   display:grid; place-items:center;
   background:linear-gradient(135deg,var(--bg1),var(--bg2));
-  --hero-gap:var(--space-2xl);
+  --hero-gap:var(--space-4xl);
   margin-bottom:var(--hero-gap);
   /* Default: Hanken via global body; Montserrat scoped to .hb-hero-A */
 
@@ -118,23 +118,7 @@
   font-family:var(--font-montserrat);
 }
 
-#hero-section .hb-hero .hb-hero-B,
-#hero-section .hb-hero .hb-hero-B *{
-  font-family:var(--font-hanken);
-  -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility;
-}
-
-/* ---------- 6) Rechte Spalte: Hanken + CTA ---------- */
-#hero-section .hb-hero .hb-hero-B h2,
-#hero-section .hb-hero .hb-hero-B h3{
-  font-weight:400; line-height:1; margin:0 0 .5rem;
-  font-size:clamp(2.5rem,2.2vw,3.3rem); color:#fff; text-wrap:balance;
-}
-#hero-section .hb-hero .hb-hero-B p{
-  font-weight:300; line-height:1.5; max-width:60ch;
-  font-size:clamp(1.6rem,1.4vw,1.6rem); color:rgba(255,255,255,.92);
-  text-wrap:pretty;
-}
+/* ---------- 6) Rechte Spalte: CTA ---------- */
 
 /* CTA – Stellschrauben */
 #hero-section{
@@ -188,11 +172,11 @@
 
 /* Desktop ab 1024px – normaler Zustand */
 @media (min-width:1024px){
-  #hero-section{
+  #hero-section{ 
     --brandSize: clamp(6.2rem, 8.8vw, 14rem);
     --tagOffsetY:.90em;
     --subMin:1rem; --subVW:1.35vw; --subMax:1.35rem;
-    --hero-gap:var(--space-xl);
+    --hero-gap:var(--space-3xl);
   }
   #hero-section .hb-hero{ width:min(96vw,1100px); } /* Bühne breiter */
 }
@@ -211,7 +195,6 @@
     --brandSize: clamp(4rem, 46vw, 9rem);
     --subMin:.95rem; --subVW:3.2vw; --subMax:1.12rem; --subMobileScale:.95;
   }
-  #hero-section .hb-hero{ width:min(94vw,700px); }
-  #hero-section .hb-hero .hb-hero-subline{ font-size:clamp(.9rem,3.6vw,1.1rem); }
-  #hero-section .hb-hero .hb-hero-B p{ line-height:1.55; }
-}
+    #hero-section .hb-hero{ width:min(94vw,700px); }
+    #hero-section .hb-hero .hb-hero-subline{ font-size:clamp(.9rem,3.6vw,1.1rem); }
+  }

--- a/css/hb_hero.css
+++ b/css/hb_hero.css
@@ -33,10 +33,10 @@
   height:min(100svh,700px);
   display:grid; place-items:center;
   background:linear-gradient(135deg,var(--bg1),var(--bg2));
-  font-family:'Montserrat',sans-serif;
+  font-family:var(--font-montserrat);
 
   /* Reveal-Timing */
-  --heroDelay:.25s; --heroDur:.30s;
+  --heroDelay:var(--dur-medium); --heroDur:var(--dur-base);
 }
 
 /* ---------- 2) Container + Gruppen-Reveal ---------- */
@@ -50,7 +50,7 @@
   text-align:left; overflow:hidden;
 
   opacity:0; filter:blur(8px); transform:translateY(12px);
-  animation:heroReveal var(--heroDur) ease var(--heroDelay) forwards;
+  animation:heroReveal var(--heroDur) var(--ease-standard) var(--heroDelay) forwards;
   will-change:opacity,filter,transform;
 }
 @keyframes heroReveal{ to{ opacity:1; filter:none; transform:none; } }
@@ -68,17 +68,17 @@
   position:absolute; left:var(--aiOffsetX,0); top:0;
   transform:translateY(var(--aiBaselineFix,.10em));
   color:var(--t2); font-weight:800; letter-spacing:-.02em; pointer-events:none; z-index:1;
-  opacity:0; animation:heroAiFade .6s ease .9s forwards;
+  opacity:0; animation:heroAiFade var(--dur-slow) var(--ease-standard) .9s forwards;
 }
 @keyframes heroAiFade{ to{ opacity:1; } }
 
 /* ---------- 4) Tagline + Subline ---------- */
 #hero-section .hb-hero .hb-hero-tagline{
-  display:block !important; /* nie neben BRAND */
-  color:var(--t2) !important; font-weight:800 !important; text-transform:uppercase !important;
-  letter-spacing:.02em !important;
-  font-size:calc(clamp(var(--tagMin),var(--tagVW),var(--tagMax))*var(--brandScale,1)) !important;
-  transform:translate(var(--tagOffsetX,0),var(--tagOffsetY,0)) !important;
+  display:block; /* nie neben BRAND */
+  color:var(--t2); font-weight:800; text-transform:uppercase;
+  letter-spacing:.02em;
+  font-size:calc(clamp(var(--tagMin),var(--tagVW),var(--tagMax))*var(--brandScale,1));
+  transform:translate(var(--tagOffsetX,0),var(--tagOffsetY,0));
 }
 #hero-section .hb-hero-subline{
   margin:0; font-weight:600; font-style:italic; color:#fff;
@@ -95,7 +95,7 @@
   content:""; position:absolute; inset:-25%;
   background:radial-gradient(closest-side,var(--glowColor) 0%,transparent 70%);
   filter:blur(28px); opacity:0; transform:translate(-18%,12%) scale(.85);
-  animation:heroAmbient var(--glowDur) ease-in-out calc(var(--heroDelay)+var(--heroDur)) infinite alternate;
+  animation:heroAmbient var(--glowDur) var(--ease-in-out) calc(var(--heroDelay)+var(--heroDur)) infinite alternate;
   pointer-events:none; z-index:0;
 }
 @keyframes heroAmbient{
@@ -111,17 +111,18 @@
   #hero-section .hb-hero::after{ animation:none; opacity:0; }
 }
 
-/* Einheitlich Montserrat im Hero (links) */
-#hero-section, #hero-section .hb-hero, #hero-section .hb-hero *{
-  font-family:'Montserrat',sans-serif !important;
+#hero-section .hb-hero .hb-hero-A,
+#hero-section .hb-hero .hb-hero-A *{
+  font-family:var(--font-montserrat);
+}
+
+#hero-section .hb-hero .hb-hero-B,
+#hero-section .hb-hero .hb-hero-B *{
+  font-family:var(--font-hanken);
+  -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility;
 }
 
 /* ---------- 6) Rechte Spalte: Hanken + CTA ---------- */
-#hero-section .hb-hero .hb-hero-B,
-#hero-section .hb-hero .hb-hero-B *{
-  font-family:"Hanken Grotesk","Hanken",system-ui,-apple-system,"Segoe UI",Roboto,Arial,sans-serif !important;
-  -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility;
-}
 #hero-section .hb-hero .hb-hero-B h2,
 #hero-section .hb-hero .hb-hero-B h3{
   font-weight:400; line-height:1; margin:0 0 .5rem;
@@ -135,12 +136,13 @@
 
 /* CTA – Stellschrauben */
 #hero-section{
-  --cta-padding-y:2.2rem; --cta-padding-x:2.6rem; --cta-radius:14px; --cta-gap:.55rem;
+  --cta-padding-y:var(--space-xl); --cta-padding-x:var(--space-2xl); --cta-radius:var(--radius-l); --cta-gap:.55rem;
   --cta-font-weight:600;
   --cta-font-size-min:1.05rem; --cta-font-size-fluid:1.35vw; --cta-font-size-max:1.8rem;
-  --cta-shadow-1:0 10px 24px rgba(0,0,0,.28); --cta-shadow-2:0 2px 0 rgba(255,255,255,.12) inset;
-  --cta-shadow-1-hover:0 14px 30px rgba(0,0,0,.32); --cta-shadow-2-hover:0 2px 0 rgba(255,255,255,.16) inset;
-  --cta-shadow-1-active:0 8px 18px rgba(0,0,0,.25); --cta-shadow-2-active:0 1px 0 rgba(255,255,255,.12) inset;
+  --cta-shadow-1:var(--shadow-md); --cta-shadow-2:var(--shadow-inset);
+  --cta-shadow-1-hover:var(--shadow-md-hover); --cta-shadow-2-hover:var(--shadow-inset-hover);
+  --cta-shadow-1-active:var(--shadow-md-active); --cta-shadow-2-active:var(--shadow-inset-active);
+  --cta-transition:var(--dur-fast) var(--ease-in-out);
 }
 #hero-section .hb-hero .hb-hero-B .hb-cta{
   display:inline-flex; align-items:center; gap:var(--cta-gap);
@@ -150,6 +152,7 @@
   line-height:1; letter-spacing:.01em; text-decoration:none; color:#fff;
   background:linear-gradient(135deg,var(--top-grad-1,#2d5eff),var(--top-grad-2,#7d32df) 50%,var(--top-grad-3,#ff4bc0) 85%);
   box-shadow:var(--cta-shadow-1),var(--cta-shadow-2); margin-top:.85rem; transform:translateZ(0);
+  transition:transform var(--cta-transition), filter var(--cta-transition), box-shadow var(--cta-transition);
 }
 #hero-section .hb-hero .hb-hero-B .hb-cta:hover{
   transform:translateY(-2px); filter:saturate(1.075);
@@ -206,6 +209,6 @@
     --subMin:.95rem; --subVW:3.2vw; --subMax:1.12rem; --subMobileScale:.95;
   }
   #hero-section .hb-hero{ width:min(94vw,700px); }
-  #hero-section .hb-hero .hb-hero-subline{ font-size:clamp(.9rem,3.6vw,1.1rem) !important; }
+  #hero-section .hb-hero .hb-hero-subline{ font-size:clamp(.9rem,3.6vw,1.1rem); }
   #hero-section .hb-hero .hb-hero-B p{ line-height:1.55; }
 }

--- a/css/hb_hero.css
+++ b/css/hb_hero.css
@@ -33,6 +33,8 @@
   height:min(100svh,700px);
   display:grid; place-items:center;
   background:linear-gradient(135deg,var(--bg1),var(--bg2));
+  --hero-gap:var(--space-2xl);
+  margin-bottom:var(--hero-gap);
   /* Default: Hanken via global body; Montserrat scoped to .hb-hero-A */
 
   /* Reveal-Timing */
@@ -118,6 +120,7 @@
 
 #hero-section .hb-hero .hb-hero-B,
 #hero-section .hb-hero .hb-hero-B *{
+  font-family:var(--font-hanken);
   -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility;
 }
 
@@ -189,6 +192,7 @@
     --brandSize: clamp(6.2rem, 8.8vw, 14rem);
     --tagOffsetY:.90em;
     --subMin:1rem; --subVW:1.35vw; --subMax:1.35rem;
+    --hero-gap:var(--space-xl);
   }
   #hero-section .hb-hero{ width:min(96vw,1100px); } /* Bühne breiter */
 }

--- a/css/hb_hero.css
+++ b/css/hb_hero.css
@@ -33,7 +33,7 @@
   height:min(100svh,700px);
   display:grid; place-items:center;
   background:linear-gradient(135deg,var(--bg1),var(--bg2));
-  font-family:var(--font-montserrat);
+  /* Default: Hanken via global body; Montserrat scoped to .hb-hero-A */
 
   /* Reveal-Timing */
   --heroDelay:var(--dur-medium); --heroDur:var(--dur-base);
@@ -118,7 +118,6 @@
 
 #hero-section .hb-hero .hb-hero-B,
 #hero-section .hb-hero .hb-hero-B *{
-  font-family:var(--font-hanken);
   -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility;
 }
 

--- a/css/hb_style.css
+++ b/css/hb_style.css
@@ -11,6 +11,8 @@
   --space-l:1.5rem;
   --space-xl:2.2rem;
   --space-2xl:2.6rem;
+  --space-3xl:5.5rem;
+  --space-4xl:8rem;
 
   /* Radius */
   --radius-s:4px;

--- a/css/hb_style.css
+++ b/css/hb_style.css
@@ -1187,9 +1187,6 @@ body::after{
           mask-image:linear-gradient(to bottom, #000 0, #000 32vh, transparent 100%);
 }
 
-/* Hero & Sections transparent, damit Gradient sichtbar ist */
-#hero-section{ background:transparent !important; }
-
 /* Ausnahmen behalten ihren eigenen Hintergrund */
 section:not(#works):not(#action):not(#slider):not(#vision1),
 .section:not(#works):not(#action):not(#slider):not(#vision1){

--- a/css/hb_style.css
+++ b/css/hb_style.css
@@ -1,3 +1,41 @@
+/* Design Tokens */
+:root{
+  /* Type */
+  --font-montserrat:'Montserrat',sans-serif;
+  --font-hanken:'Hanken Grotesk','Hanken',system-ui,-apple-system,'Segoe UI',Roboto,Arial,sans-serif;
+
+  /* Space */
+  --space-xs:0.25rem;
+  --space-s:0.5rem;
+  --space-m:1rem;
+  --space-l:1.5rem;
+  --space-xl:2.2rem;
+  --space-2xl:2.6rem;
+
+  /* Radius */
+  --radius-s:4px;
+  --radius-m:8px;
+  --radius-l:14px;
+
+  /* Shadow */
+  --shadow-md:0 10px 24px rgba(0,0,0,.28);
+  --shadow-md-hover:0 14px 30px rgba(0,0,0,.32);
+  --shadow-md-active:0 8px 18px rgba(0,0,0,.25);
+  --shadow-inset:0 2px 0 rgba(255,255,255,.12) inset;
+  --shadow-inset-hover:0 2px 0 rgba(255,255,255,.16) inset;
+  --shadow-inset-active:0 1px 0 rgba(255,255,255,.12) inset;
+
+  /* Duration */
+  --dur-fast:.2s;
+  --dur-medium:.25s;
+  --dur-base:.3s;
+  --dur-slow:.6s;
+
+  /* Easing */
+  --ease-standard:cubic-bezier(0.4,0,0.2,1);
+  --ease-in-out:ease-in-out;
+}
+
 /* BASIS TYPO */
 p {
   text-align: left;
@@ -8,9 +46,12 @@ p {
 p::first-line {
   hyphens: none;
 }
+a{
+  transition: color var(--dur-fast) var(--ease-standard);
+}
 
 body, p {
-  font-family: 'Hanken Grotesk', sans-serif;
+  font-family: var(--font-hanken);
   font-weight: 300;
   font-size: 1.9rem;
   line-height: 1.4;
@@ -20,7 +61,7 @@ body, p {
 }
 
 h1, h2 {
-  font-family: 'Hanken Grotesk', sans-serif;
+  font-family: var(--font-hanken);
   font-weight: 700;
   font-size: 2.8rem;
   margin-top: 2.0rem;
@@ -29,7 +70,7 @@ h1, h2 {
 }
 
 h3, h4 {
-  font-family: 'Hanken Grotesk', sans-serif;
+  font-family: var(--font-hanken);
   font-weight: 600;
   font-size: 1.75rem;
   margin-top: 2rem;
@@ -41,7 +82,7 @@ h3, h4 {
 
 
 h5, h6 {
-  font-family: 'Hanken Grotesk', sans-serif;
+  font-family: var(--font-hanken);
   font-weight: 600;
   font-size: 1.75rem;
   margin-top: 2rem;
@@ -73,7 +114,7 @@ h5, h6 {
 
 
 .h2-special {
-  font-family: 'Hanken Grotesk', sans-serif;
+  font-family: var(--font-hanken);
   font-weight: 900;
   font-size: clamp(4rem, 5vw, 6rem);
   color: #3d4654;
@@ -86,7 +127,7 @@ h5, h6 {
 
 
 .h2-special_2 {
-  font-family: 'Hanken Grotesk', sans-serif;
+  font-family: var(--font-hanken);
   font-weight: 900; /* Fett, wie gewünscht */
   font-size: clamp(6rem, 6vw, 10rem); /* Skaliert von 4rem bis 6rem für Desktop */
   color: #3d4654; /* brandfont */
@@ -102,7 +143,7 @@ h5, h6 {
 
 
 .h2-special_3 {
-  font-family: 'Hanken Grotesk', sans-serif;
+  font-family: var(--font-hanken);
   font-weight: 900; /* Fett, wie gewünscht */
   font-size: clamp(7rem, 7vw, 11rem); /* Skaliert von 4rem bis 6rem für Desktop */
   color: #fff; /* brandfont */
@@ -116,7 +157,7 @@ h5, h6 {
 
 
 .h3-headline {
-  font-family: 'Hanken Grotesk', sans-serif;
+  font-family: var(--font-hanken);
   font-weight: 700;
   font-size: clamp(4rem, 5vw, 6rem);
   color: #3d4654;
@@ -129,7 +170,7 @@ h5, h6 {
 
 
 .h4-special {
-  font-family: 'Hanken Grotesk', sans-serif;
+  font-family: var(--font-hanken);
   font-weight: 700;
   font-size: clamp(3rem, 4vw, 5rem);
   color: #fff;
@@ -143,7 +184,7 @@ h5, h6 {
 
 
 .italic-inline {
-  font-family: 'Hanken Grotesk', sans-serif;
+  font-family: var(--font-hanken);
   font-style: italic;
   font-weight: 900;
   letter-spacing: -0.05em;
@@ -816,7 +857,7 @@ max-height: 30px;
 
 
 .chapter-number {
-  font-family: 'Hanken Grotesk', sans-serif;
+    font-family: var(--font-hanken);
   font-weight: 900;
   font-size: clamp(25rem, 40vw, 30rem);
   color: rgba(32, 124, 250, 0.2);
@@ -841,7 +882,7 @@ max-height: 30px;
   top: 80%;
   left: 80%;
   transform: translate(-20%, -20%);
-  font-family: 'Montserrat', sans-serif;
+   font-family: var(--font-montserrat);
   font-weight: bolder;
   line-height: 1.2em;
   font-size: 3em;
@@ -942,8 +983,8 @@ section, .section {
 }
 .last-cta {
   font-size: clamp(1rem, 1.5vw, 1.2rem);
-  margin-top: 1rem;
-  transition: background-color 0.2s ease;
+  margin-top: var(--space-m);
+  transition: background-color var(--dur-fast) var(--ease-standard);
 }
 .last-cta:hover {
   background-color: #3c64b0;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "hbdistrict",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node ci/screenshot.mjs"
+  },
+  "devDependencies": {
+    "playwright": "^1.41.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add design tokens for type, spacing, radius, shadow, duration, and easing
- map hero and CTA styling to tokens and drop unneeded `!important`
- align link and call-to-action hover states with new duration/easing tokens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9de2d805083209a1ed889e691e9f1