### PR TITLE
refactor: align rebuild palette with reference

### DIFF
--- a/004_packdat/README.md
+++ b/004_packdat/README.md
@@ -1,0 +1,36 @@
+# HB District – Rebuild Guide
+
+## Projektüberblick
+Die Rebuild-Version der Website liegt im Ordner `z_Rebuild/` und ersetzt das bisherige Bootstrap-Setup durch TailwindCSS (CDN) in Kombination mit einem Custom-Token-System. Alle Inhalte, Medien und Interaktionen wurden übernommen und für ein fluid-responsives Layout optimiert.
+
+## Schnellstart
+1. Öffne `z_Rebuild/00_index_rebuilt.html` direkt im Browser. Alle Abhängigkeiten werden über lokale Dateien oder CDNs geladen – ein Build-Schritt ist nicht zwingend nötig.
+2. Stelle sicher, dass der Ordner `img/`, `video/` und `fonts/` auf derselben Ebene wie `z_Rebuild/` liegt, damit Medien und Icons korrekt geladen werden.
+
+## Entwicklung mit Tailwind
+Für lokale Anpassungen ohne CDN kann Tailwind per CLI erzeugt werden:
+```bash
+cd z_Rebuild
+npx tailwindcss -i ./00_base_rebuilt.css -o ../dist/hb.bundle.css --watch
+```
+- Die Konfiguration liegt in `z_Rebuild/00_tailwind.config.js`.
+- Das Token-Set (`z_Rebuild/00_custom_tokens_rebuild.css`) bleibt die Quelle für Farben, Typografie, Abstände und Effekte.
+- Entferne im HTML die CDN-Einbindung, wenn du auf ein lokales Bundle wechselst.
+
+## Custom Tokens anpassen
+Alle Designparameter befinden sich in `00_custom_tokens_rebuild.css`.
+- **Farben & Gradients:** `--hb-color-*` und `--hb-gradient-*`
+- **Typografie:** `--hb-font-*`, `--hb-text-*`, `--hb-display-*`
+- **Spacing & Radius:** `--hb-space-*`, `--hb-radius-*`
+- **Motion:** Passe die Keyframes (`hbFadeUp`, `hbMarquee`, …) oder die `--hb-duration-*` Variablen an.
+
+## Komponenten & Interaktionen
+- `00_base_rebuilt.css` stellt Layout-Layer, Glas-Optiken, Carousel-Styling und Utilities bereit.
+- `00_main_rebuilt.js` enthält native Implementierungen für Navigation, Carousel, Smooth Scrolling, Video-Embed und Scroll-Reveal.
+- Motion reagiert auf `prefers-reduced-motion` und pausiert Carousel sowie Partner-Marquee automatisch.
+
+## Pflegehinweise
+- Nutze die vorhandenen Utility-Klassen (`stack-lg`, `grid-auto-fit`, `hb-card` …) für neue Inhalte, um das fluid-responsives Verhalten zu erhalten.
+- Neue Sektionen sollten `data-reveal` nutzen, damit sie automatisch in den Scroll-Reveal eingebunden werden.
+- Achte bei weiteren Videos/Slides darauf, `data-carousel-media` bzw. `data-has-video` zu setzen, damit die Autoplay-Logik greift.
+

--- a/004_packdat/z_Rebuild/00_base_rebuilt.css
+++ b/004_packdat/z_Rebuild/00_base_rebuilt.css
@@ -126,273 +126,223 @@
     margin-inline: auto;
   }
 
-  .site-header {
-    position: sticky;
-    top: 0;
-    z-index: var(--hb-z-nav);
-    padding-block: clamp(0.35rem, 0.2rem + 0.6vw, 0.9rem);
-    background: linear-gradient(180deg, rgba(255, 255, 255, 0.88) 0%, rgba(255, 255, 255, 0.72) 100%);
-    backdrop-filter: var(--hb-blur-lg);
+  #nav-main {
+    position: fixed;
+    inset: 0 0 auto;
+    z-index: 100;
+    background: var(--hb-gradient-nav);
+    backdrop-filter: blur(12px);
+    padding: clamp(0.75rem, 0.6rem + 0.4vw, 1rem) clamp(2rem, 8vw, 5rem);
   }
 
-  .site-header::after {
-    content: "";
-    position: absolute;
-    inset-inline: 0;
-    bottom: 0;
-    height: 1px;
-    background: linear-gradient(90deg, transparent, rgba(34, 101, 255, 0.35), transparent);
-    opacity: 0;
-    transition: opacity var(--hb-duration-base) ease;
+  #nav-main.is-scrolled {
+    box-shadow: 0 12px 40px rgba(32, 124, 250, 0.18);
   }
 
-  .site-header.is-scrolled::after {
-    opacity: 1;
+  .nav-main__inner {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: clamp(1.2rem, 1rem + 1vw, 2.6rem);
+    max-width: 1530px;
+    margin-inline: auto;
+    font-family: var(--hb-font-sans);
+    letter-spacing: 0.05em;
+    color: rgba(0, 0, 0, 0.8);
   }
 
-  .site-nav {
+  .nav-main__brand {
+    font-family: var(--hb-font-display);
+    font-weight: 700;
+    font-size: clamp(1.1rem, 1rem + 0.4vw, 1.5rem);
+    text-transform: uppercase;
+    color: rgba(0, 0, 0, 0.85);
+  }
+
+  .nav-main__links {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: clamp(1.4rem, 1.1rem + 1vw, 2.8rem);
+    font-size: clamp(0.9rem, 0.85rem + 0.2vw, 1rem);
+    text-transform: uppercase;
+  }
+
+  .nav-main__links a,
+  .nav-main__link {
+    color: rgba(0, 0, 0, 0.8);
+    font-weight: 600;
+    transition: color var(--hb-duration-base) ease;
+  }
+
+  .nav-main__links a:hover,
+  .nav-main__link:hover,
+  .nav-main__links a:focus-visible,
+  .nav-main__link:focus-visible {
+    color: rgba(32, 124, 250, 0.85);
+  }
+
+  .nav-main__meta {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    gap: var(--hb-space-3);
-    border: 1px solid var(--hb-color-border-subtle);
-    border-radius: var(--hb-radius-xl);
-    padding: clamp(0.6rem, 0.45rem + 0.4vw, 0.9rem);
-    background: rgba(255, 255, 255, 0.86);
-    box-shadow: var(--hb-shadow-soft);
-    backdrop-filter: var(--hb-blur-md);
-    position: relative;
-  }
-
-  .nav-brand {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--hb-space-2);
-    font-size: var(--hb-text-sm);
-    font-weight: 600;
-    letter-spacing: 0.08em;
+    gap: clamp(1rem, 0.8rem + 0.8vw, 2rem);
+    font-size: clamp(0.9rem, 0.85rem + 0.2vw, 1rem);
     text-transform: uppercase;
-    color: var(--hb-color-muted-strong);
   }
 
-  .nav-logo {
-    width: clamp(140px, 12vw, 180px);
-    aspect-ratio: 5 / 1.3;
-    object-fit: contain;
-    filter: drop-shadow(0 10px 28px rgba(77, 121, 230, 0.25));
-  }
-
-  .nav-toggle {
+  .nav-main__cta {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: clamp(44px, 10vw, 52px);
-    height: clamp(44px, 10vw, 52px);
-    border-radius: var(--hb-radius-pill);
-    background: rgba(255, 255, 255, 0.92);
-    border: 1px solid rgba(31, 93, 255, 0.35);
-    color: var(--hb-color-heading);
-    transition: transform var(--hb-duration-base) ease, background var(--hb-duration-base) ease;
-  }
-
-  .nav-toggle[aria-expanded="true"] {
-    background: rgba(255, 255, 255, 0.98);
-    transform: rotate(90deg);
-  }
-
-  .nav-toggle svg {
-    width: 1.35rem;
-    height: 1.35rem;
-  }
-
-  .nav-backdrop {
-    position: fixed;
-    inset: 0;
-    background: rgba(215, 228, 255, 0.55);
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity var(--hb-duration-base) ease;
-    backdrop-filter: blur(12px);
-  }
-
-  .site-header.is-nav-open .nav-backdrop {
-    opacity: 1;
-    pointer-events: auto;
-  }
-
-  .nav-panel {
-    position: fixed;
-    inset-inline: clamp(1.5rem, 8vw, 4rem);
-    top: clamp(4.5rem, 6vw, 7rem);
-    border-radius: var(--hb-radius-xl);
-    border: 1px solid var(--hb-color-glass-border);
-    background: var(--hb-gradient-panel);
-    box-shadow: var(--hb-shadow-glass);
-    padding: clamp(1.5rem, 1.2rem + 1vw, 2.5rem);
-    transform: translateY(-8%) scale(0.96);
-    transform-origin: top right;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity var(--hb-duration-base) ease, transform var(--hb-duration-base) ease;
-    display: grid;
-    gap: var(--hb-space-5);
-    max-height: calc(100vh - clamp(5rem, 10vw, 7rem));
-    overflow-y: auto;
-    z-index: var(--hb-z-overlay);
-  }
-
-  .nav-panel[data-open="true"] {
-    opacity: 1;
-    pointer-events: auto;
-    transform: translateY(0) scale(1);
-  }
-
-  .nav-panel-group {
-    display: grid;
-    gap: var(--hb-space-2);
-  }
-
-  .nav-panel a {
-    font-size: var(--hb-text-md);
-    color: var(--hb-color-muted-strong);
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-  }
-
-  .nav-panel a:hover {
-    color: var(--hb-color-accent-alt);
-  }
-
-  .nav-cta {
-    justify-self: start;
-    padding-inline: clamp(1.4rem, 1.1rem + 0.8vw, 2rem);
-    padding-block: clamp(0.65rem, 0.5rem + 0.2vw, 0.9rem);
-    border-radius: var(--hb-radius-pill);
-    border: 1px solid rgba(255, 77, 218, 0.45);
-    background: linear-gradient(120deg, rgba(255, 77, 218, 0.22) 0%, rgba(0, 210, 255, 0.28) 100%);
+    padding-inline: clamp(1.4rem, 1.2rem + 0.6vw, 2.1rem);
+    padding-block: clamp(0.55rem, 0.45rem + 0.3vw, 0.9rem);
+    border-radius: 9999px;
+    background: var(--hb-gradient-cta-inverse);
+    box-shadow: 0 0 20px rgba(255, 75, 192, 0.4);
     color: #ffffff;
-    font-weight: 600;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-    box-shadow: var(--hb-shadow-glow);
+    font-weight: 700;
+    letter-spacing: 0.08em;
   }
 
-  .nav-inline {
-    display: none;
+  .nav-main__cta:hover {
+    color: #ffffff;
+    filter: brightness(1.05);
   }
 
-  @media (width >= 64rem) {
-    .nav-toggle {
-      display: none;
-    }
-
-    .nav-panel,
-    .nav-backdrop {
-      display: none;
-    }
-
-    .nav-inline {
-      display: flex;
-      align-items: center;
-      gap: var(--hb-space-4);
-      font-size: var(--hb-text-sm);
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-    }
-
-    .nav-inline a {
-      color: var(--hb-color-muted-strong);
-      transition: color var(--hb-duration-base) ease;
-    }
-
-    .nav-inline a:hover,
-    .nav-inline a:focus-visible {
-      color: var(--hb-color-accent-alt);
-    }
-
-    .nav-inline .nav-cta {
-      padding-block: clamp(0.55rem, 0.45rem + 0.2vw, 0.8rem);
-      padding-inline: clamp(1.2rem, 1rem + 0.4vw, 1.6rem);
-      font-size: var(--hb-text-sm);
-    }
-  }
-
-  .hero-section {
-    padding-block: var(--hb-space-12);
-    background: var(--hb-gradient-hero);
+  .hero {
     position: relative;
-    overflow: hidden;
-  }
-
-  .hero-section::after {
-    content: "";
-    position: absolute;
-    inset: 10% -40% -35% -40%;
-    background: radial-gradient(circle at center, rgba(81, 136, 255, 0.25) 0%, transparent 70%);
-    filter: blur(120px);
-    opacity: 0.55;
-    pointer-events: none;
-    z-index: -1;
-  }
-
-  .hero-grid {
-    display: grid;
-    gap: var(--hb-space-8);
+    display: flex;
     align-items: center;
-    grid-template-columns: repeat(auto-fit, minmax(min(320px, 100%), 1fr));
+    justify-content: center;
+    text-align: center;
+    padding-block: clamp(6rem, 5rem + 4vw, 8rem);
+    background-image: var(--hb-hero-highlight), var(--hb-gradient-hero);
+    background-repeat: no-repeat;
+    background-size: 100% 100%, cover;
+    background-position: center;
   }
 
-  .hero-tagline {
-    font-size: var(--hb-text-md);
+  .hero__inner {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: clamp(1.5rem, 1.2rem + 1vw, 2.4rem);
+    max-width: min(95vw, 1530px);
+    margin-inline: auto;
+  }
+
+  .hero__tagline {
+    font-size: clamp(1rem, 0.9rem + 0.4vw, 1.4rem);
     letter-spacing: 0.6em;
     text-transform: uppercase;
-    color: var(--hb-color-muted-strong);
-    margin-bottom: var(--hb-space-2);
+    color: rgba(15, 27, 69, 0.7);
+    margin: 0;
   }
 
-  .hero-brand {
-    font-size: var(--hb-display-hero);
+  .hero__title {
+    font-family: var(--hb-font-display);
     font-weight: 800;
-    line-height: 0.92;
-    letter-spacing: -0.04em;
-    position: relative;
-  }
-
-  .hero-brand .brand-anchor {
-    display: inline-flex;
-    position: relative;
-    margin-inline: clamp(0.4rem, 0.3rem + 0.4vw, 0.8rem);
-  }
-
-  .hero-brand .brand-anchor::after {
-    content: "";
-    position: absolute;
-    inset: 60% -15% -15% -15%;
-    background: radial-gradient(circle at center, rgba(99, 240, 255, 0.55), transparent 70%);
-    filter: blur(18px);
-    z-index: -1;
-  }
-
-  .hero-brand .brand-A {
-    color: var(--hb-color-accent);
-  }
-
-  .hero-brand .hero-ai {
-    color: var(--hb-color-accent-alt);
-    font-size: clamp(2.3rem, 1.8rem + 2.4vw, 4.2rem);
-    font-weight: 700;
-    letter-spacing: -0.05em;
-  }
-
-  .hero-subline {
-    display: inline-flex;
-    flex-wrap: wrap;
-    gap: var(--hb-space-1);
-    margin-bottom: var(--hb-space-5);
+    font-size: clamp(4rem, 3rem + 5vw, 7rem);
+    margin: 0;
+    line-height: 0.9;
     text-transform: uppercase;
-    letter-spacing: 0.3em;
-    font-size: clamp(0.78rem, 0.7rem + 0.25vw, 0.95rem);
-    color: var(--hb-color-muted);
+    background: var(--hb-gradient-text-hero);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+
+  .hero__subline {
+    font-size: clamp(0.85rem, 0.8rem + 0.25vw, 1rem);
+    letter-spacing: 0.4em;
+    text-transform: uppercase;
+    color: rgba(20, 40, 85, 0.65);
+    margin: 0;
+  }
+
+  .hero__claim {
+    font-family: var(--hb-font-display);
+    font-size: clamp(1.6rem, 1.4rem + 1vw, 2.4rem);
+    line-height: 1.2;
+    color: rgba(15, 27, 69, 0.85);
+    margin: 0;
+  }
+
+  .hero__glass {
+    max-width: clamp(18rem, 60vw, 780px);
+    padding: clamp(1.8rem, 1.6rem + 1vw, 2.6rem) clamp(2.4rem, 2rem + 1.5vw, 3.5rem);
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    background: rgba(255, 255, 255, 0.2);
+    backdrop-filter: blur(20px);
+    box-shadow: 0 24px 60px rgba(32, 124, 250, 0.18);
+  }
+
+  .hero__glass p {
+    margin: 0;
+    color: rgba(32, 42, 79, 0.8);
+    font-size: clamp(1rem, 0.95rem + 0.2vw, 1.15rem);
+    line-height: 1.65;
+  }
+
+  .hero__cta {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding-inline: clamp(2rem, 1.8rem + 1vw, 3rem);
+    padding-block: clamp(0.8rem, 0.7rem + 0.3vw, 1.1rem);
+    border-radius: 9999px;
+    background: var(--hb-gradient-cta);
+    color: #ffffff;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    box-shadow: 0 8px 32px rgba(32, 124, 250, 0.4);
+  }
+
+  .hero__cta:hover {
+    color: #ffffff;
+    filter: brightness(1.05);
+  }
+
+  @media (max-width: 900px) {
+    .nav-main__inner {
+      grid-template-columns: 1fr;
+      text-align: center;
+      gap: clamp(1rem, 0.8rem + 0.8vw, 1.8rem);
+    }
+
+    .nav-main__links,
+    .nav-main__meta {
+      justify-content: center;
+      flex-wrap: wrap;
+    }
+
+    .hero {
+      padding-block: clamp(5rem, 4.5rem + 3vw, 6.5rem);
+    }
+  }
+
+  @media (max-width: 480px) {
+    #nav-main {
+      padding-inline: clamp(1.2rem, 10vw, 1.8rem);
+    }
+
+    .hero__inner {
+      gap: clamp(1.2rem, 1rem + 0.8vw, 1.6rem);
+    }
+
+    .hero__subline {
+      letter-spacing: 0.3em;
+    }
+
+    .hero__claim {
+      font-size: clamp(1.4rem, 1.3rem + 0.6vw, 1.8rem);
+    }
+
+    .hero__glass {
+      padding: clamp(1.6rem, 1.4rem + 1vw, 2.2rem) clamp(1.4rem, 1.2rem + 1vw, 2rem);
+    }
   }
 
   .hb-cta {
@@ -423,46 +373,6 @@
     box-shadow: inset 0 0 0 1px rgba(31, 93, 255, 0.1);
   }
 
-  .hb-glass {
-    padding: clamp(1.8rem, 1.5rem + 0.9vw, 2.8rem);
-    border-radius: var(--hb-radius-xl);
-    border: 1px solid var(--hb-color-glass-border);
-    background: var(--hb-color-surface-strong);
-    backdrop-filter: blur(24px);
-    box-shadow: var(--hb-shadow-glass);
-    display: grid;
-    gap: var(--hb-space-3);
-  }
-
-  .hb-glass h2 {
-    font-size: clamp(1.85rem, 1.6rem + 0.8vw, 2.6rem);
-  }
-
-  .hb-glass p {
-    color: var(--hb-color-text);
-  }
-
-  .word-badge {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding-inline: clamp(0.6rem, 0.5rem + 0.2vw, 0.85rem);
-    padding-block: clamp(0.35rem, 0.3rem + 0.15vw, 0.5rem);
-    border-radius: var(--hb-radius-pill);
-    font-size: clamp(0.7rem, 0.66rem + 0.14vw, 0.85rem);
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-  }
-
-  .word-badge--pink {
-    background: rgba(255, 77, 218, 0.24);
-    color: var(--hb-color-heading);
-  }
-
-  .word-badge--blue {
-    background: rgba(0, 210, 255, 0.24);
-    color: var(--hb-color-heading);
-  }
 
   .section-muted {
     background: rgba(255, 255, 255, 0.8);

--- a/004_packdat/z_Rebuild/00_base_rebuilt.css
+++ b/004_packdat/z_Rebuild/00_base_rebuilt.css
@@ -1,0 +1,961 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  html {
+    font-family: var(--hb-font-sans);
+    background-color: var(--hb-color-body);
+    color: var(--hb-color-text);
+    scroll-behavior: smooth;
+    text-rendering: optimizeLegibility;
+  }
+
+  body {
+    margin: 0;
+    min-height: 100vh;
+    background: linear-gradient(180deg, #f5f8ff 0%, #ffffff 55%, #edf3ff 100%);
+    color: var(--hb-color-text);
+    line-height: 1.65;
+    font-size: var(--hb-text-base);
+    -webkit-font-smoothing: antialiased;
+  }
+
+  main {
+    display: block;
+    position: relative;
+    isolation: isolate;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: var(--hb-font-display);
+    color: var(--hb-color-heading);
+    margin: 0 0 var(--hb-space-3);
+    font-weight: 700;
+    letter-spacing: -0.01em;
+  }
+
+  h1 {
+    font-size: var(--hb-display-hero);
+    line-height: 0.98;
+  }
+
+  h2 {
+    font-size: var(--hb-display-sub);
+    line-height: 1.05;
+  }
+
+  h3 {
+    font-size: var(--hb-text-xl);
+  }
+
+  h4 {
+    font-size: var(--hb-text-lg);
+  }
+
+  p {
+    margin: 0 0 var(--hb-space-3);
+    font-size: var(--hb-text-base);
+    color: var(--hb-color-text);
+  }
+
+  a {
+    color: var(--hb-color-accent-alt);
+    text-decoration: none;
+    transition: color var(--hb-duration-base) ease, filter var(--hb-duration-base) ease;
+  }
+
+  a:hover {
+    color: var(--hb-color-accent);
+  }
+
+  a:focus-visible,
+  button:focus-visible {
+    outline: 2px solid var(--hb-color-accent-alt);
+    outline-offset: 4px;
+  }
+
+  img,
+  video {
+    display: block;
+    max-width: 100%;
+    height: auto;
+  }
+
+  ul,
+  ol {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  button {
+    font: inherit;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: inherit;
+  }
+
+  section {
+    position: relative;
+    padding-block: var(--hb-space-10);
+    scroll-margin-top: clamp(6rem, 5rem + 2vw, 7.5rem);
+  }
+
+  ::selection {
+    background: rgba(255, 77, 218, 0.35);
+    color: var(--hb-color-heading);
+  }
+}
+
+@layer components {
+  .hb-container {
+    width: min(var(--hb-container-max), 100% - clamp(2rem, 8vw, 6rem));
+    margin-inline: auto;
+  }
+
+  .site-header {
+    position: sticky;
+    top: 0;
+    z-index: var(--hb-z-nav);
+    padding-block: clamp(0.35rem, 0.2rem + 0.6vw, 0.9rem);
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.88) 0%, rgba(255, 255, 255, 0.72) 100%);
+    backdrop-filter: var(--hb-blur-lg);
+  }
+
+  .site-header::after {
+    content: "";
+    position: absolute;
+    inset-inline: 0;
+    bottom: 0;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, rgba(34, 101, 255, 0.35), transparent);
+    opacity: 0;
+    transition: opacity var(--hb-duration-base) ease;
+  }
+
+  .site-header.is-scrolled::after {
+    opacity: 1;
+  }
+
+  .site-nav {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--hb-space-3);
+    border: 1px solid var(--hb-color-border-subtle);
+    border-radius: var(--hb-radius-xl);
+    padding: clamp(0.6rem, 0.45rem + 0.4vw, 0.9rem);
+    background: rgba(255, 255, 255, 0.86);
+    box-shadow: var(--hb-shadow-soft);
+    backdrop-filter: var(--hb-blur-md);
+    position: relative;
+  }
+
+  .nav-brand {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--hb-space-2);
+    font-size: var(--hb-text-sm);
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--hb-color-muted-strong);
+  }
+
+  .nav-logo {
+    width: clamp(140px, 12vw, 180px);
+    aspect-ratio: 5 / 1.3;
+    object-fit: contain;
+    filter: drop-shadow(0 10px 28px rgba(77, 121, 230, 0.25));
+  }
+
+  .nav-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: clamp(44px, 10vw, 52px);
+    height: clamp(44px, 10vw, 52px);
+    border-radius: var(--hb-radius-pill);
+    background: rgba(255, 255, 255, 0.92);
+    border: 1px solid rgba(31, 93, 255, 0.35);
+    color: var(--hb-color-heading);
+    transition: transform var(--hb-duration-base) ease, background var(--hb-duration-base) ease;
+  }
+
+  .nav-toggle[aria-expanded="true"] {
+    background: rgba(255, 255, 255, 0.98);
+    transform: rotate(90deg);
+  }
+
+  .nav-toggle svg {
+    width: 1.35rem;
+    height: 1.35rem;
+  }
+
+  .nav-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(215, 228, 255, 0.55);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--hb-duration-base) ease;
+    backdrop-filter: blur(12px);
+  }
+
+  .site-header.is-nav-open .nav-backdrop {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .nav-panel {
+    position: fixed;
+    inset-inline: clamp(1.5rem, 8vw, 4rem);
+    top: clamp(4.5rem, 6vw, 7rem);
+    border-radius: var(--hb-radius-xl);
+    border: 1px solid var(--hb-color-glass-border);
+    background: var(--hb-gradient-panel);
+    box-shadow: var(--hb-shadow-glass);
+    padding: clamp(1.5rem, 1.2rem + 1vw, 2.5rem);
+    transform: translateY(-8%) scale(0.96);
+    transform-origin: top right;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--hb-duration-base) ease, transform var(--hb-duration-base) ease;
+    display: grid;
+    gap: var(--hb-space-5);
+    max-height: calc(100vh - clamp(5rem, 10vw, 7rem));
+    overflow-y: auto;
+    z-index: var(--hb-z-overlay);
+  }
+
+  .nav-panel[data-open="true"] {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0) scale(1);
+  }
+
+  .nav-panel-group {
+    display: grid;
+    gap: var(--hb-space-2);
+  }
+
+  .nav-panel a {
+    font-size: var(--hb-text-md);
+    color: var(--hb-color-muted-strong);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .nav-panel a:hover {
+    color: var(--hb-color-accent-alt);
+  }
+
+  .nav-cta {
+    justify-self: start;
+    padding-inline: clamp(1.4rem, 1.1rem + 0.8vw, 2rem);
+    padding-block: clamp(0.65rem, 0.5rem + 0.2vw, 0.9rem);
+    border-radius: var(--hb-radius-pill);
+    border: 1px solid rgba(255, 77, 218, 0.45);
+    background: linear-gradient(120deg, rgba(255, 77, 218, 0.22) 0%, rgba(0, 210, 255, 0.28) 100%);
+    color: #ffffff;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    box-shadow: var(--hb-shadow-glow);
+  }
+
+  .nav-inline {
+    display: none;
+  }
+
+  @media (width >= 64rem) {
+    .nav-toggle {
+      display: none;
+    }
+
+    .nav-panel,
+    .nav-backdrop {
+      display: none;
+    }
+
+    .nav-inline {
+      display: flex;
+      align-items: center;
+      gap: var(--hb-space-4);
+      font-size: var(--hb-text-sm);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .nav-inline a {
+      color: var(--hb-color-muted-strong);
+      transition: color var(--hb-duration-base) ease;
+    }
+
+    .nav-inline a:hover,
+    .nav-inline a:focus-visible {
+      color: var(--hb-color-accent-alt);
+    }
+
+    .nav-inline .nav-cta {
+      padding-block: clamp(0.55rem, 0.45rem + 0.2vw, 0.8rem);
+      padding-inline: clamp(1.2rem, 1rem + 0.4vw, 1.6rem);
+      font-size: var(--hb-text-sm);
+    }
+  }
+
+  .hero-section {
+    padding-block: var(--hb-space-12);
+    background: var(--hb-gradient-hero);
+    position: relative;
+    overflow: hidden;
+  }
+
+  .hero-section::after {
+    content: "";
+    position: absolute;
+    inset: 10% -40% -35% -40%;
+    background: radial-gradient(circle at center, rgba(81, 136, 255, 0.25) 0%, transparent 70%);
+    filter: blur(120px);
+    opacity: 0.55;
+    pointer-events: none;
+    z-index: -1;
+  }
+
+  .hero-grid {
+    display: grid;
+    gap: var(--hb-space-8);
+    align-items: center;
+    grid-template-columns: repeat(auto-fit, minmax(min(320px, 100%), 1fr));
+  }
+
+  .hero-tagline {
+    font-size: var(--hb-text-md);
+    letter-spacing: 0.6em;
+    text-transform: uppercase;
+    color: var(--hb-color-muted-strong);
+    margin-bottom: var(--hb-space-2);
+  }
+
+  .hero-brand {
+    font-size: var(--hb-display-hero);
+    font-weight: 800;
+    line-height: 0.92;
+    letter-spacing: -0.04em;
+    position: relative;
+  }
+
+  .hero-brand .brand-anchor {
+    display: inline-flex;
+    position: relative;
+    margin-inline: clamp(0.4rem, 0.3rem + 0.4vw, 0.8rem);
+  }
+
+  .hero-brand .brand-anchor::after {
+    content: "";
+    position: absolute;
+    inset: 60% -15% -15% -15%;
+    background: radial-gradient(circle at center, rgba(99, 240, 255, 0.55), transparent 70%);
+    filter: blur(18px);
+    z-index: -1;
+  }
+
+  .hero-brand .brand-A {
+    color: var(--hb-color-accent);
+  }
+
+  .hero-brand .hero-ai {
+    color: var(--hb-color-accent-alt);
+    font-size: clamp(2.3rem, 1.8rem + 2.4vw, 4.2rem);
+    font-weight: 700;
+    letter-spacing: -0.05em;
+  }
+
+  .hero-subline {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: var(--hb-space-1);
+    margin-bottom: var(--hb-space-5);
+    text-transform: uppercase;
+    letter-spacing: 0.3em;
+    font-size: clamp(0.78rem, 0.7rem + 0.25vw, 0.95rem);
+    color: var(--hb-color-muted);
+  }
+
+  .hb-cta {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding-inline: clamp(1.6rem, 1.3rem + 0.8vw, 2.3rem);
+    padding-block: clamp(0.7rem, 0.55rem + 0.25vw, 0.95rem);
+    border-radius: var(--hb-radius-pill);
+    border: 1px solid rgba(255, 77, 218, 0.5);
+    background: linear-gradient(135deg, rgba(255, 77, 218, 0.28), rgba(0, 210, 255, 0.32));
+    color: #ffffff;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    box-shadow: var(--hb-shadow-glow);
+    transition: transform var(--hb-duration-base) ease;
+  }
+
+  .hb-cta:hover {
+    transform: translateY(-2px);
+  }
+
+  .hb-cta.is-secondary {
+    border-color: rgba(31, 93, 255, 0.3);
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(233, 242, 255, 0.95));
+    color: var(--hb-color-primary-strong);
+    box-shadow: inset 0 0 0 1px rgba(31, 93, 255, 0.1);
+  }
+
+  .hb-glass {
+    padding: clamp(1.8rem, 1.5rem + 0.9vw, 2.8rem);
+    border-radius: var(--hb-radius-xl);
+    border: 1px solid var(--hb-color-glass-border);
+    background: var(--hb-color-surface-strong);
+    backdrop-filter: blur(24px);
+    box-shadow: var(--hb-shadow-glass);
+    display: grid;
+    gap: var(--hb-space-3);
+  }
+
+  .hb-glass h2 {
+    font-size: clamp(1.85rem, 1.6rem + 0.8vw, 2.6rem);
+  }
+
+  .hb-glass p {
+    color: var(--hb-color-text);
+  }
+
+  .word-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding-inline: clamp(0.6rem, 0.5rem + 0.2vw, 0.85rem);
+    padding-block: clamp(0.35rem, 0.3rem + 0.15vw, 0.5rem);
+    border-radius: var(--hb-radius-pill);
+    font-size: clamp(0.7rem, 0.66rem + 0.14vw, 0.85rem);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .word-badge--pink {
+    background: rgba(255, 77, 218, 0.24);
+    color: var(--hb-color-heading);
+  }
+
+  .word-badge--blue {
+    background: rgba(0, 210, 255, 0.24);
+    color: var(--hb-color-heading);
+  }
+
+  .section-muted {
+    background: rgba(255, 255, 255, 0.8);
+  }
+
+  .hb-grid-auto {
+    display: grid;
+    gap: var(--hb-space-6);
+    grid-template-columns: repeat(auto-fit, minmax(min(280px, 100%), 1fr));
+  }
+
+  .hb-card {
+    padding: clamp(1.8rem, 1.5rem + 0.8vw, 2.6rem);
+    border-radius: var(--hb-radius-lg);
+    border: 1px solid rgba(123, 150, 230, 0.35);
+    background: linear-gradient(160deg, rgba(255, 255, 255, 0.96), rgba(236, 245, 255, 0.86));
+    box-shadow: var(--hb-shadow-soft);
+    display: grid;
+    gap: var(--hb-space-3);
+    height: 100%;
+  }
+
+  .hb-card-icon {
+    width: clamp(3rem, 2.4rem + 1.2vw, 3.6rem);
+    height: clamp(3rem, 2.4rem + 1.2vw, 3.6rem);
+    border-radius: 24px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, rgba(31, 93, 255, 0.16), rgba(0, 196, 255, 0.16));
+    color: var(--hb-color-primary-strong);
+    box-shadow: inset 0 0 0 1px rgba(31, 93, 255, 0.2);
+  }
+
+  .hb-card h3,
+  .hb-card h2 {
+    font-size: clamp(1.45rem, 1.3rem + 0.65vw, 1.9rem);
+  }
+
+  .hb-card p {
+    color: var(--hb-color-text);
+  }
+
+  .hb-video-shell {
+    display: grid;
+    gap: var(--hb-space-4);
+  }
+
+  .video-trigger {
+    position: relative;
+    border-radius: var(--hb-radius-lg);
+    overflow: hidden;
+    border: 1px solid rgba(123, 150, 230, 0.3);
+    cursor: pointer;
+    box-shadow: var(--hb-shadow-soft);
+  }
+
+  .video-trigger img {
+    width: 100%;
+    height: auto;
+    object-fit: cover;
+  }
+
+  .video-trigger::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(140deg, rgba(255, 255, 255, 0.08) 0%, rgba(197, 214, 255, 0.4) 100%);
+  }
+
+  .video-trigger button {
+    position: absolute;
+    inset: 50% auto auto 50%;
+    transform: translate(-50%, -50%);
+    width: clamp(68px, 9vw, 88px);
+    aspect-ratio: 1;
+    border-radius: 50%;
+    border: 1px solid rgba(31, 93, 255, 0.4);
+    background: radial-gradient(circle at center, rgba(255, 255, 255, 0.95), rgba(199, 223, 255, 0.8));
+    display: grid;
+    place-items: center;
+    color: var(--hb-color-primary-strong);
+    box-shadow: 0 18px 40px rgba(91, 132, 240, 0.35);
+  }
+
+  .video-trigger svg {
+    width: clamp(26px, 4vw, 32px);
+    height: clamp(26px, 4vw, 32px);
+  }
+
+  .video-frame iframe,
+  .video-frame video {
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    border: 0;
+    border-radius: var(--hb-radius-lg);
+  }
+
+  .section-heading {
+    max-width: clamp(28rem, 24rem + 12vw, 48rem);
+    color: var(--hb-color-muted-strong);
+  }
+
+  .works-intro {
+    display: grid;
+    gap: var(--hb-space-6);
+    grid-template-columns: repeat(auto-fit, minmax(min(320px, 100%), 1fr));
+  }
+
+  .works-carousel {
+    position: relative;
+    border-radius: var(--hb-radius-xl);
+    border: 1px solid rgba(123, 150, 230, 0.32);
+    background: rgba(255, 255, 255, 0.96);
+    backdrop-filter: blur(18px);
+    overflow: hidden;
+    box-shadow: var(--hb-shadow-soft);
+  }
+
+  .carousel-track {
+    display: flex;
+    transition: transform var(--hb-duration-slow) ease;
+    will-change: transform;
+  }
+
+  .carousel-slide {
+    flex: 0 0 100%;
+    display: grid;
+    gap: var(--hb-space-5);
+    grid-template-columns: repeat(auto-fit, minmax(min(320px, 100%), 1fr));
+    align-items: center;
+    padding: clamp(1.8rem, 1.4rem + 1.2vw, 3rem);
+  }
+
+  .carousel-media {
+    border-radius: var(--hb-radius-lg);
+    overflow: hidden;
+    border: 1px solid rgba(123, 150, 230, 0.28);
+    background: rgba(255, 255, 255, 0.94);
+  }
+
+  .carousel-body {
+    display: grid;
+    gap: var(--hb-space-3);
+  }
+
+  .carousel-body h3,
+  .carousel-body h2 {
+    font-size: clamp(1.9rem, 1.6rem + 0.9vw, 2.6rem);
+  }
+
+  .carousel-body p {
+    color: var(--hb-color-text);
+  }
+
+  .carousel-controls {
+    position: absolute;
+    inset-block-end: clamp(1rem, 0.8rem + 1vw, 2rem);
+    inset-inline-end: clamp(1rem, 0.8rem + 1vw, 2rem);
+    display: inline-flex;
+    gap: var(--hb-space-2);
+  }
+
+  .carousel-button {
+    width: clamp(44px, 10vw, 56px);
+    aspect-ratio: 1;
+    border-radius: var(--hb-radius-pill);
+    border: 1px solid rgba(31, 93, 255, 0.35);
+    background: rgba(255, 255, 255, 0.92);
+    color: var(--hb-color-primary-strong);
+    display: grid;
+    place-items: center;
+    transition: background var(--hb-duration-base) ease, transform var(--hb-duration-base) ease;
+  }
+
+  .carousel-button:hover {
+    background: linear-gradient(135deg, rgba(31, 93, 255, 0.12), rgba(0, 196, 255, 0.12));
+    transform: translateY(-2px);
+  }
+
+  .carousel-button svg {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+
+  .chapter-number {
+    position: absolute;
+    inset-block-start: var(--hb-space-6);
+    inset-inline-start: clamp(0.8rem, 0.5rem + 1.2vw, 2rem);
+    font-size: clamp(2.6rem, 2.2rem + 1.8vw, 4.4rem);
+    font-family: var(--hb-font-display);
+    font-weight: 700;
+    color: rgba(31, 93, 255, 0.15);
+    pointer-events: none;
+  }
+
+  .vision-shell {
+    display: grid;
+    gap: var(--hb-space-4);
+    max-width: min(900px, 100%);
+  }
+
+  .vision-shell p {
+    color: var(--hb-color-text);
+  }
+
+  .vision-title {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: var(--hb-space-2);
+  }
+
+  .vision-title span {
+    font-size: clamp(2.2rem, 1.9rem + 1.4vw, 3.4rem);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .vision-title .accent-blue {
+    color: var(--hb-color-accent-alt);
+  }
+
+  .vision-title .accent-navy {
+    color: var(--hb-color-heading);
+  }
+
+  .vision-title .accent-gradient {
+    background: linear-gradient(120deg, var(--hb-color-accent) 0%, var(--hb-color-accent-alt) 100%);
+    -webkit-background-clip: text;
+    color: transparent;
+  }
+
+  .braind-mark {
+    display: inline-flex;
+    gap: clamp(0.4rem, 0.3rem + 0.4vw, 0.85rem);
+    font-size: clamp(2.5rem, 2rem + 2.2vw, 4.6rem);
+    font-weight: 800;
+    letter-spacing: -0.04em;
+  }
+
+  .braind-mark span {
+    display: inline-block;
+  }
+
+  .braind-mark .accent {
+    color: var(--hb-color-accent);
+  }
+
+  .braind-mark .accent-alt {
+    color: var(--hb-color-accent-alt);
+  }
+
+  .partner-marquee {
+    position: relative;
+    overflow: hidden;
+    border-radius: var(--hb-radius-xl);
+    border: 1px solid rgba(123, 150, 230, 0.3);
+    background: var(--hb-gradient-partner);
+    padding-block: var(--hb-space-5);
+    padding-inline: clamp(1.5rem, 1rem + 2vw, 3.5rem);
+    mask-image: linear-gradient(90deg, transparent 0%, black 12%, black 88%, transparent 100%);
+  }
+
+  .partner-track {
+    display: flex;
+    align-items: center;
+    gap: clamp(3rem, 2rem + 3vw, 6rem);
+    animation: hbMarquee 32s linear infinite;
+  }
+
+  .partner-track img {
+    max-height: clamp(28px, 2.4vw, 48px);
+    width: auto;
+    filter: drop-shadow(0 10px 24px rgba(91, 132, 240, 0.18));
+  }
+
+  .contact-shell {
+    display: grid;
+    gap: var(--hb-space-8);
+    grid-template-columns: repeat(auto-fit, minmax(min(320px, 100%), 1fr));
+    align-items: center;
+  }
+
+  .social-buttons {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: var(--hb-space-3);
+  }
+
+  .social-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--hb-space-2);
+    padding-inline: clamp(1.2rem, 1rem + 0.6vw, 1.8rem);
+    padding-block: clamp(0.55rem, 0.45rem + 0.2vw, 0.8rem);
+    border-radius: var(--hb-radius-pill);
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    border: 1px solid rgba(31, 93, 255, 0.35);
+    color: var(--hb-color-primary-strong);
+    transition: transform var(--hb-duration-base) ease, border-color var(--hb-duration-base) ease;
+  }
+
+  .social-btn i {
+    font-size: 1.1em;
+  }
+
+  .social-btn.is-primary {
+    background: linear-gradient(125deg, rgba(255, 255, 255, 0.96), rgba(230, 240, 255, 0.86));
+    color: var(--hb-color-primary-strong);
+  }
+
+  .social-btn.is-outline {
+    background: rgba(255, 255, 255, 0.9);
+  }
+
+  .social-btn:hover {
+    transform: translateY(-2px);
+    border-color: rgba(255, 68, 200, 0.55);
+  }
+
+  .bulb-hero {
+    position: relative;
+    display: grid;
+    place-items: center;
+  }
+
+  .bulb-hero img {
+    width: min(360px, 100%);
+    filter: drop-shadow(0 28px 60px rgba(255, 68, 200, 0.28)) drop-shadow(0 18px 48px rgba(0, 196, 255, 0.25));
+  }
+
+  .bulb-glow {
+    position: absolute;
+    inset: auto;
+    width: min(360px, 80%);
+    aspect-ratio: 1 / 1;
+    border-radius: 50%;
+    background: radial-gradient(circle at center, rgba(0, 210, 255, 0.28), transparent 70%);
+    filter: blur(70px);
+    z-index: -1;
+  }
+
+  .site-footer {
+    background: var(--hb-gradient-footer);
+    color: #ffffff;
+    padding-block: var(--hb-space-5);
+  }
+
+  .footer-bar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--hb-space-3);
+  }
+
+  .footer-brand {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--hb-space-2);
+    font-size: var(--hb-text-sm);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: currentColor;
+  }
+
+  .footer-brand img {
+    height: clamp(26px, 2.1vw, 40px);
+    width: auto;
+    filter: brightness(0) invert(1);
+  }
+
+  .footer-links {
+    display: inline-flex;
+    gap: var(--hb-space-3);
+    align-items: center;
+  }
+
+  .footer-links a {
+    color: currentColor;
+    font-size: 1.2rem;
+  }
+
+  .top-link {
+    position: fixed;
+    inset-inline-end: clamp(1rem, 0.8rem + 1.5vw, 2.4rem);
+    inset-block-end: clamp(1.4rem, 1rem + 1.8vw, 3rem);
+    width: clamp(48px, 10vw, 60px);
+    aspect-ratio: 1;
+    border-radius: var(--hb-radius-pill);
+    background: rgba(255, 255, 255, 0.92);
+    border: 1px solid rgba(31, 93, 255, 0.28);
+    display: grid;
+    place-items: center;
+    color: var(--hb-color-primary-strong);
+    box-shadow: var(--hb-shadow-soft);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--hb-duration-base) ease, transform var(--hb-duration-base) ease;
+  }
+
+  .top-link.is-visible {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .top-link:hover {
+    transform: translateY(-4px);
+  }
+}
+
+@layer utilities {
+  .text-balance {
+    text-wrap: balance;
+  }
+
+  .max-w-reading {
+    max-width: clamp(32rem, 28rem + 10vw, 52rem);
+  }
+
+  .stack-lg {
+    display: grid;
+    gap: var(--hb-space-5);
+  }
+
+  .stack-xl {
+    display: grid;
+    gap: var(--hb-space-7);
+  }
+
+  .grid-auto-fit {
+    display: grid;
+    gap: var(--hb-space-6);
+    grid-template-columns: repeat(auto-fit, minmax(min(300px, 100%), 1fr));
+  }
+
+  .bg-panel {
+    background: rgba(255, 255, 255, 0.92);
+    border-radius: var(--hb-radius-xl);
+    border: 1px solid rgba(123, 150, 230, 0.32);
+  }
+
+  .backdrop-glass {
+    background: rgba(255, 255, 255, 0.88);
+    backdrop-filter: blur(18px);
+  }
+
+  .reveal-ready {
+    opacity: 0;
+    transform: translate3d(0, var(--hb-space-4), 0);
+  }
+
+  .reveal-active {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+    transition: opacity var(--hb-duration-slow) ease, transform var(--hb-duration-slow) ease;
+  }
+
+  [data-reveal] {
+    opacity: 0;
+    transform: translate3d(0, var(--hb-space-4), 0);
+  }
+
+  [data-reveal].is-visible {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+    transition: opacity var(--hb-duration-slow) ease, transform var(--hb-duration-slow) ease;
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .partner-track {
+    animation-duration: 1ms;
+  }
+
+  .hb-cta,
+  .carousel-button,
+  .social-btn,
+  .top-link {
+    transition-duration: 1ms;
+  }
+}

--- a/004_packdat/z_Rebuild/00_custom_tokens_rebuild.css
+++ b/004_packdat/z_Rebuild/00_custom_tokens_rebuild.css
@@ -63,12 +63,15 @@
   --hb-color-footer: #081b61;
 
   /* Gradients */
-  --hb-gradient-hero: radial-gradient(circle at 15% 25%, rgba(108, 167, 255, 0.45) 0%, transparent 55%),
-    radial-gradient(circle at 80% 20%, rgba(255, 215, 255, 0.62) 0%, transparent 60%),
-    linear-gradient(150deg, #f5f8ff 0%, #ffffff 60%, #d9e9ff 100%);
+  --hb-gradient-hero: linear-gradient(135deg, #207cfa 20%, #8fc7ff 60%, #d4e6ff 100%);
+  --hb-hero-highlight: radial-gradient(circle at center, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0) 60%);
   --hb-gradient-panel: linear-gradient(160deg, rgba(255, 255, 255, 0.96) 0%, rgba(249, 254, 255, 0.82) 65%);
   --hb-gradient-footer: linear-gradient(100deg, #ff3ac7 0%, #2aa3ff 100%);
   --hb-gradient-partner: radial-gradient(circle at center, rgba(197, 215, 255, 0.68), rgba(240, 247, 255, 0.95));
+  --hb-gradient-nav: linear-gradient(90deg, rgba(255, 255, 255, 0.3) 0%, rgba(255, 255, 255, 0.15) 100%);
+  --hb-gradient-cta: linear-gradient(120deg, #ff4bc0 0%, #207cfa 100%);
+  --hb-gradient-cta-inverse: linear-gradient(120deg, #207cfa 0%, #ff4bc0 100%);
+  --hb-gradient-text-hero: linear-gradient(90deg, #207cfa 0%, #ff4bc0 100%);
 
   /* Blur */
   --hb-blur-sm: blur(12px);

--- a/004_packdat/z_Rebuild/00_custom_tokens_rebuild.css
+++ b/004_packdat/z_Rebuild/00_custom_tokens_rebuild.css
@@ -1,0 +1,190 @@
+:root {
+  color-scheme: light;
+
+  /* Typography */
+  --hb-font-sans: "Hanken Grotesk", "Hanken", "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+  --hb-font-display: "Montserrat", "Hanken Grotesk", "Hanken", "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+
+  --hb-text-xs: clamp(0.72rem, 0.68rem + 0.2vw, 0.78rem);
+  --hb-text-sm: clamp(0.82rem, 0.76rem + 0.3vw, 0.95rem);
+  --hb-text-base: clamp(1rem, 0.94rem + 0.35vw, 1.18rem);
+  --hb-text-md: clamp(1.2rem, 1.1rem + 0.5vw, 1.5rem);
+  --hb-text-lg: clamp(1.45rem, 1.3rem + 0.65vw, 1.85rem);
+  --hb-text-xl: clamp(1.8rem, 1.6rem + 1vw, 2.6rem);
+  --hb-display-sub: clamp(2.2rem, 1.9rem + 1.5vw, 3.4rem);
+  --hb-display-hero: clamp(3.4rem, 2.6rem + 4.2vw, 6.4rem);
+
+  /* Layout */
+  --hb-container-max: 1200px;
+  --hb-space-0: 0;
+  --hb-space-1: clamp(0.35rem, 0.26rem + 0.25vw, 0.55rem);
+  --hb-space-2: clamp(0.55rem, 0.42rem + 0.35vw, 0.85rem);
+  --hb-space-3: clamp(0.75rem, 0.6rem + 0.45vw, 1.2rem);
+  --hb-space-4: clamp(1rem, 0.8rem + 0.55vw, 1.55rem);
+  --hb-space-5: clamp(1.35rem, 1.1rem + 0.7vw, 2rem);
+  --hb-space-6: clamp(1.75rem, 1.4rem + 0.9vw, 2.6rem);
+  --hb-space-7: clamp(2.25rem, 1.8rem + 1.1vw, 3.25rem);
+  --hb-space-8: clamp(2.85rem, 2.3rem + 1.35vw, 4.1rem);
+  --hb-space-9: clamp(3.4rem, 2.7rem + 1.6vw, 4.9rem);
+  --hb-space-10: clamp(4.2rem, 3.2rem + 2vw, 6rem);
+  --hb-space-11: clamp(5.1rem, 3.9rem + 2.6vw, 7.2rem);
+  --hb-space-12: clamp(6rem, 4.6rem + 3.2vw, 8.6rem);
+
+  /* Radii */
+  --hb-radius-xs: clamp(0.35rem, 0.3rem + 0.15vw, 0.5rem);
+  --hb-radius-sm: clamp(0.55rem, 0.45rem + 0.25vw, 0.85rem);
+  --hb-radius-md: clamp(0.9rem, 0.7rem + 0.35vw, 1.25rem);
+  --hb-radius-lg: clamp(1.4rem, 1.1rem + 0.55vw, 2rem);
+  --hb-radius-xl: clamp(2.1rem, 1.6rem + 0.9vw, 3.1rem);
+  --hb-radius-pill: 999px;
+
+  /* Shadows */
+  --hb-shadow-soft: 0 18px 50px rgba(21, 60, 170, 0.18);
+  --hb-shadow-glass: 0 30px 70px rgba(63, 104, 214, 0.18);
+  --hb-shadow-glow: 0 0 42px rgba(79, 138, 255, 0.45);
+
+  /* Colors */
+  --hb-color-body: #f5f8ff;
+  --hb-color-body-soft: #eef3ff;
+  --hb-color-surface: rgba(255, 255, 255, 0.78);
+  --hb-color-surface-strong: rgba(255, 255, 255, 0.92);
+  --hb-color-surface-solid: #ffffff;
+  --hb-color-glass-border: rgba(99, 136, 255, 0.35);
+  --hb-color-primary: #1f5dff;
+  --hb-color-primary-strong: #1546d8;
+  --hb-color-accent: #ff44c8;
+  --hb-color-accent-alt: #00c4ff;
+  --hb-color-highlight: #5ad7ff;
+  --hb-color-muted: #5c6f9b;
+  --hb-color-muted-strong: #2a3871;
+  --hb-color-text: #202a4f;
+  --hb-color-heading: #0f1b45;
+  --hb-color-border-subtle: rgba(123, 150, 230, 0.35);
+  --hb-color-footer: #081b61;
+
+  /* Gradients */
+  --hb-gradient-hero: radial-gradient(circle at 15% 25%, rgba(108, 167, 255, 0.45) 0%, transparent 55%),
+    radial-gradient(circle at 80% 20%, rgba(255, 215, 255, 0.62) 0%, transparent 60%),
+    linear-gradient(150deg, #f5f8ff 0%, #ffffff 60%, #d9e9ff 100%);
+  --hb-gradient-panel: linear-gradient(160deg, rgba(255, 255, 255, 0.96) 0%, rgba(249, 254, 255, 0.82) 65%);
+  --hb-gradient-footer: linear-gradient(100deg, #ff3ac7 0%, #2aa3ff 100%);
+  --hb-gradient-partner: radial-gradient(circle at center, rgba(197, 215, 255, 0.68), rgba(240, 247, 255, 0.95));
+
+  /* Blur */
+  --hb-blur-sm: blur(12px);
+  --hb-blur-md: blur(18px);
+  --hb-blur-lg: blur(28px);
+
+  /* Durations */
+  --hb-duration-quick: 160ms;
+  --hb-duration-base: 260ms;
+  --hb-duration-slow: 480ms;
+
+  /* Z-Index */
+  --hb-z-nav: 40;
+  --hb-z-overlay: 45;
+  --hb-z-dialog: 50;
+}
+
+@keyframes hbFadeUp {
+  from {
+    opacity: 0;
+    transform: translate3d(0, var(--hb-space-4), 0);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes hbGlowPulse {
+  0% {
+    box-shadow: 0 0 0 rgba(255, 77, 218, 0.0);
+  }
+  50% {
+    box-shadow: 0 0 45px rgba(99, 240, 255, 0.45);
+  }
+  100% {
+    box-shadow: 0 0 0 rgba(255, 77, 218, 0.0);
+  }
+}
+
+@keyframes hbMarquee {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-50%);
+  }
+}
+
+@keyframes hbFloat {
+  0% {
+    transform: translate3d(0, 0, 0);
+  }
+  50% {
+    transform: translate3d(0, -8px, 0);
+  }
+  100% {
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes hbGradientShift {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --hb-duration-quick: 1ms;
+    --hb-duration-base: 1ms;
+    --hb-duration-slow: 1ms;
+  }
+
+  @keyframes hbFadeUp {
+    from {
+      opacity: 1;
+      transform: none;
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+
+  @keyframes hbGlowPulse {
+    from,
+    to {
+      box-shadow: none;
+    }
+  }
+
+  @keyframes hbMarquee {
+    from,
+    to {
+      transform: translateX(0);
+    }
+  }
+
+  @keyframes hbFloat {
+    from,
+    to {
+      transform: none;
+    }
+  }
+
+  @keyframes hbGradientShift {
+    from,
+    to {
+      background-position: 0% 50%;
+    }
+  }
+}

--- a/004_packdat/z_Rebuild/00_index_rebuilt.html
+++ b/004_packdat/z_Rebuild/00_index_rebuilt.html
@@ -71,89 +71,41 @@
     <link rel="stylesheet" href="./00_base_rebuilt.css" />
   </head>
   <body class="antialiased text-hb-text bg-hb-bg" id="page-top">
-    <header class="site-header" data-site-header>
-      <div class="hb-container">
-        <div class="site-nav" data-site-nav>
-          <a class="nav-brand" href="#hero-section">
-            <img class="nav-logo" src="../img/main/braind_logo_und_claim.svg" alt="BRAiND" />
-            <span class="sr-only">Zurück zum Seitenanfang</span>
-          </a>
-
-          <nav class="nav-inline" aria-label="Hauptnavigation">
-            <a class="tracking-[0.4em] text-xs text-hb-text/80" href="#video-bio">Profil</a>
-            <a class="tracking-[0.4em] text-xs text-hb-text/80" href="#focus">Expertise</a>
-            <a class="tracking-[0.4em] text-xs text-hb-text/80" href="#works">Projekte</a>
-            <a class="tracking-[0.4em] text-xs text-hb-text/80" href="#vision1">Brand+AI</a>
-            <a class="tracking-[0.4em] text-xs text-hb-text/80" href="#Kontakt">Kontakt</a>
-            <a class="nav-cta" href="#Kontakt">Jetzt sprechen</a>
-          </nav>
-
-          <button
-            class="nav-toggle"
-            type="button"
-            aria-expanded="false"
-            aria-controls="primary-navigation"
-            data-nav-toggle
-          >
-            <span class="sr-only">Navigation öffnen</span>
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
-              <path d="M4 6h16M4 12h16M4 18h16" />
-            </svg>
-          </button>
+    <header id="nav-main" class="nav-main" data-site-header>
+      <div class="nav-main__inner">
+        <a class="nav-main__brand" href="#hero" aria-label="Zurück zum Seitenanfang">BRAND</a>
+        <nav class="nav-main__links" aria-label="Hauptnavigation">
+          <a href="#video-bio">Profil</a>
+          <a href="#focus">Expertise</a>
+          <a href="#works">Projekte</a>
+        </nav>
+        <div class="nav-main__meta">
+          <a href="#vision1" class="nav-main__link">Brand+AI</a>
+          <a href="#Kontakt" class="nav-main__link">Kontakt</a>
+          <a href="#Kontakt" class="nav-main__cta">JETZT SPRECHEN</a>
         </div>
       </div>
-      <div class="nav-backdrop" aria-hidden="true" data-nav-backdrop></div>
-      <nav class="nav-panel" aria-label="Hauptnavigation" id="primary-navigation" data-nav-panel data-open="false">
-        <div class="nav-panel-group" role="list">
-          <a href="#hero-section" class="tracking-[0.45em] uppercase">Home</a>
-          <a href="#video-bio" class="tracking-[0.45em] uppercase">Profil</a>
-          <a href="#focus" class="tracking-[0.45em] uppercase">Expertise</a>
-          <a href="#works" class="tracking-[0.45em] uppercase">Projekte</a>
-          <a href="#vision1" class="tracking-[0.45em] uppercase">Brand + AI</a>
-          <a href="#Kontakt" class="tracking-[0.45em] uppercase">Kontakt</a>
-        </div>
-        <a class="nav-cta" href="#Kontakt">Jetzt sprechen</a>
-      </nav>
     </header>
 
     <main>
-      <section id="hero-section" class="hero-section" aria-labelledby="hb-tagline">
-        <div class="hb-container">
-          <div class="hero-grid">
-            <div class="stack-xl" data-reveal>
-              <p class="hero-tagline" id="hb-tagline">SHAPE YOUR</p>
-              <h1 class="hero-brand" id="hb-brand" data-text="BRAND">
-                BR
-                <span class="brand-anchor">
-                  <span class="brand-A" aria-hidden="true">A</span>
-                  <span class="hero-ai" aria-hidden="true">AI</span>
-                </span>
-                ND
-              </h1>
-              <p class="hero-subline" id="hb-subline" aria-label="BRAND STRATEGY · BRAND DESIGN · AI-WORKFLOW">
-                <span>BRAND STRATEGY ·</span>
-                <span>BRAND DESIGN ·</span>
-                <span>AI - WORKFLOW</span>
-              </p>
-              <a class="hb-cta" href="#Kontakt">Wert Ihrer Marke skalieren</a>
-            </div>
-
-            <aside class="hb-glass" aria-labelledby="hb-glass-title" data-reveal>
-              <h2 id="hb-glass-title" class="text-left">
-                Produkte gehen über den Tresen.<br /><span class="italic">Marken unter die Haut.</span>
-              </h2>
-              <p>
-                Den Wert der <span class="word-badge word-badge--pink">Marke</span> in die Herzen der Menschen zu übertragen, ist
-                unabdingbar, um eine langfristige Bindung zu Ihren Kunden aufzubauen und zu erhalten. Mit klarer
-                <span class="word-badge word-badge--blue">Trennschärfe</span> zwischen Marke und Marketing gewinnen Sie Fokus auf die
-                wahren <span class="word-badge word-badge--blue">Wachstumstreiber</span> Ihrer Unternehmensstrategie. Ich baue Ihre Marke
-                auf – in fester Anstellung in Ihrem Unternehmen oder auf Projektbasis.
-              </p>
-              <div>
-                <a class="hb-cta is-secondary" href="#Kontakt">Jetzt unverbindlich sprechen</a>
-              </div>
-            </aside>
+      <section id="hero" aria-labelledby="hero-tagline" class="hero">
+        <div class="hero__inner">
+          <h2 id="hero-tagline" class="hero__tagline">SHAPE YOUR</h2>
+          <h1 class="hero__title">BRAND</h1>
+          <p class="hero__subline">BRAND STRATEGY · BRAND DESIGN · AI · WORKFLOW</p>
+          <p class="hero__claim">
+            Produkte gehen über den Tresen.<br />
+            Marken unter die Haut.
+          </p>
+          <div class="hero__glass" data-reveal>
+            <p>
+              Den Wert der Marke in die Herzen der Menschen zu übertragen, ist unabdingbar, um eine langfristige Bindung zu Ihren
+              Kunden aufzubauen und zu erhalten. Mit klarer Trennschärfe zwischen Marke und Marketing gewinnen Sie Fokus auf die
+              wahren Wachstumstreiber Ihrer Unternehmensstrategie. Ich baue Ihre Marke auf – in fester Anstellung in Ihrem
+              Unternehmen oder auf Projektbasis.
+            </p>
           </div>
+          <a class="hero__cta" href="#Kontakt">JETZT UNVERBINDLICH SPRECHEN</a>
         </div>
       </section>
 

--- a/004_packdat/z_Rebuild/00_index_rebuilt.html
+++ b/004_packdat/z_Rebuild/00_index_rebuilt.html
@@ -1,0 +1,697 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="Hendrik Bogner: Brand Manager mit KI-Expertise – Strategie, Design und KI-Workflows für starke Marken."
+    />
+    <meta name="author" content="Hendrik Bogner" />
+    <title>Hendrik Bogner | Brand Manager, Design &amp; KI - Workflow</title>
+    <link rel="shortcut icon" href="../favicon.ico" />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600;700;800&family=Hanken+Grotesk:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.tailwindcss.com"></script>
+
+    <script>
+      tailwind.config = {
+        theme: {
+          fontFamily: {
+            sans: ["Hanken Grotesk", "Hanken", "Inter", "system-ui", "-apple-system", "Segoe UI", "sans-serif"],
+            display: ["Montserrat", "Hanken Grotesk", "Hanken", "Inter", "system-ui", "-apple-system", "Segoe UI", "sans-serif"],
+          },
+          extend: {
+            colors: {
+              "hb-bg": "var(--hb-color-body)",
+              "hb-surface": "var(--hb-color-surface)",
+              "hb-primary": "var(--hb-color-primary)",
+              "hb-accent": "var(--hb-color-accent)",
+              "hb-accent-alt": "var(--hb-color-accent-alt)",
+              "hb-text": "var(--hb-color-text)",
+            },
+            spacing: {
+              "fluid-1": "var(--hb-space-1)",
+              "fluid-2": "var(--hb-space-2)",
+              "fluid-3": "var(--hb-space-3)",
+              "fluid-4": "var(--hb-space-4)",
+              "fluid-5": "var(--hb-space-5)",
+              "fluid-6": "var(--hb-space-6)",
+              "fluid-7": "var(--hb-space-7)",
+              "fluid-8": "var(--hb-space-8)",
+              "fluid-9": "var(--hb-space-9)",
+              "fluid-10": "var(--hb-space-10)",
+            },
+            borderRadius: {
+              "hb-sm": "var(--hb-radius-sm)",
+              "hb-md": "var(--hb-radius-md)",
+              "hb-lg": "var(--hb-radius-lg)",
+              "hb-xl": "var(--hb-radius-xl)",
+              "hb-pill": "var(--hb-radius-pill)",
+            },
+            boxShadow: {
+              "hb-soft": "var(--hb-shadow-soft)",
+              "hb-glow": "var(--hb-shadow-glow)",
+            },
+          },
+        },
+        corePlugins: {
+          preflight: false,
+        },
+      };
+    </script>
+
+    <link rel="stylesheet" href="./00_custom_tokens_rebuild.css" />
+    <link rel="stylesheet" href="./00_base_rebuilt.css" />
+  </head>
+  <body class="antialiased text-hb-text bg-hb-bg" id="page-top">
+    <header class="site-header" data-site-header>
+      <div class="hb-container">
+        <div class="site-nav" data-site-nav>
+          <a class="nav-brand" href="#hero-section">
+            <img class="nav-logo" src="../img/main/braind_logo_und_claim.svg" alt="BRAiND" />
+            <span class="sr-only">Zurück zum Seitenanfang</span>
+          </a>
+
+          <nav class="nav-inline" aria-label="Hauptnavigation">
+            <a class="tracking-[0.4em] text-xs text-hb-text/80" href="#video-bio">Profil</a>
+            <a class="tracking-[0.4em] text-xs text-hb-text/80" href="#focus">Expertise</a>
+            <a class="tracking-[0.4em] text-xs text-hb-text/80" href="#works">Projekte</a>
+            <a class="tracking-[0.4em] text-xs text-hb-text/80" href="#vision1">Brand+AI</a>
+            <a class="tracking-[0.4em] text-xs text-hb-text/80" href="#Kontakt">Kontakt</a>
+            <a class="nav-cta" href="#Kontakt">Jetzt sprechen</a>
+          </nav>
+
+          <button
+            class="nav-toggle"
+            type="button"
+            aria-expanded="false"
+            aria-controls="primary-navigation"
+            data-nav-toggle
+          >
+            <span class="sr-only">Navigation öffnen</span>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+              <path d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <div class="nav-backdrop" aria-hidden="true" data-nav-backdrop></div>
+      <nav class="nav-panel" aria-label="Hauptnavigation" id="primary-navigation" data-nav-panel data-open="false">
+        <div class="nav-panel-group" role="list">
+          <a href="#hero-section" class="tracking-[0.45em] uppercase">Home</a>
+          <a href="#video-bio" class="tracking-[0.45em] uppercase">Profil</a>
+          <a href="#focus" class="tracking-[0.45em] uppercase">Expertise</a>
+          <a href="#works" class="tracking-[0.45em] uppercase">Projekte</a>
+          <a href="#vision1" class="tracking-[0.45em] uppercase">Brand + AI</a>
+          <a href="#Kontakt" class="tracking-[0.45em] uppercase">Kontakt</a>
+        </div>
+        <a class="nav-cta" href="#Kontakt">Jetzt sprechen</a>
+      </nav>
+    </header>
+
+    <main>
+      <section id="hero-section" class="hero-section" aria-labelledby="hb-tagline">
+        <div class="hb-container">
+          <div class="hero-grid">
+            <div class="stack-xl" data-reveal>
+              <p class="hero-tagline" id="hb-tagline">SHAPE YOUR</p>
+              <h1 class="hero-brand" id="hb-brand" data-text="BRAND">
+                BR
+                <span class="brand-anchor">
+                  <span class="brand-A" aria-hidden="true">A</span>
+                  <span class="hero-ai" aria-hidden="true">AI</span>
+                </span>
+                ND
+              </h1>
+              <p class="hero-subline" id="hb-subline" aria-label="BRAND STRATEGY · BRAND DESIGN · AI-WORKFLOW">
+                <span>BRAND STRATEGY ·</span>
+                <span>BRAND DESIGN ·</span>
+                <span>AI - WORKFLOW</span>
+              </p>
+              <a class="hb-cta" href="#Kontakt">Wert Ihrer Marke skalieren</a>
+            </div>
+
+            <aside class="hb-glass" aria-labelledby="hb-glass-title" data-reveal>
+              <h2 id="hb-glass-title" class="text-left">
+                Produkte gehen über den Tresen.<br /><span class="italic">Marken unter die Haut.</span>
+              </h2>
+              <p>
+                Den Wert der <span class="word-badge word-badge--pink">Marke</span> in die Herzen der Menschen zu übertragen, ist
+                unabdingbar, um eine langfristige Bindung zu Ihren Kunden aufzubauen und zu erhalten. Mit klarer
+                <span class="word-badge word-badge--blue">Trennschärfe</span> zwischen Marke und Marketing gewinnen Sie Fokus auf die
+                wahren <span class="word-badge word-badge--blue">Wachstumstreiber</span> Ihrer Unternehmensstrategie. Ich baue Ihre Marke
+                auf – in fester Anstellung in Ihrem Unternehmen oder auf Projektbasis.
+              </p>
+              <div>
+                <a class="hb-cta is-secondary" href="#Kontakt">Jetzt unverbindlich sprechen</a>
+              </div>
+            </aside>
+          </div>
+        </div>
+      </section>
+
+      <section id="video-bio" class="section-muted" aria-labelledby="video-bio-title">
+        <div class="hb-container stack-xl">
+          <div class="hero-tagline text-xs tracking-[0.45em] uppercase text-hb-text/70">Profil</div>
+          <div class="hb-grid-auto">
+            <div class="hb-video-shell" data-reveal>
+              <div class="video-trigger" data-video-trigger data-video-id="y_ONEJooBqQ">
+                <img src="../img/main/yt_thumb.png" alt="Showreel Thumbnail" loading="lazy" />
+                <button type="button" aria-label="Showreel abspielen">
+                  <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+                    <circle cx="50" cy="50" r="46" stroke="currentColor" stroke-width="4" fill="none" />
+                    <polygon points="42,32 70,50 42,68" fill="currentColor" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div class="stack-xl" data-reveal>
+              <h2 id="video-bio-title" class="text-left">
+                Ich bin Hendrik Bogner – Markenexperte, International Brand Manager und Mediendesigner.
+              </h2>
+              <p class="max-w-reading">
+                Mit jahrelanger Erfahrung verbinde ich Strategie und Design, um Marken präzise zu positionieren und lebendig zu
+                machen. Analytisch, methodisch und zielorientiert – vom Messaging bis zu internationalen Markenrichtlinien. Es
+                geht darum, die Identität einer Marke für Kunden zu enthüllen und sie mit ihrem Unternehmen untrennbar zu
+                verbinden.
+              </p>
+              <div>
+                <a class="hb-cta" href="https://calendly.com/hbmailer" target="_blank" rel="noopener noreferrer"
+                  >Direkt und unkompliziert kennenlernen</a
+                >
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="focus" aria-labelledby="focus-title">
+        <div class="hb-container stack-xl">
+          <div class="stack-lg" data-reveal>
+            <h2 id="focus-title" class="text-left">
+              Marke. Design. KI.<br /><span class="italic">Verzahnt und ohne Schnittstellen.</span>
+            </h2>
+          </div>
+          <div class="grid-auto-fit" data-reveal>
+            <article class="hb-card">
+              <span class="hb-card-icon">
+                <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+                  <path
+                    d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .556 6.588A4 4 0 1 0 12 18Z"
+                  ></path>
+                  <path
+                    d="M12 5a3 3 0 1 1 5.997.125 4 4 0 0 1 2.526 5.77 4 4 0 0 1-.556 6.588A4 4 0 1 1 12 18Z"
+                  ></path>
+                  <path d="M15 13a4.5 4.5 0 0 1-3-4 4.5 4.5 0 0 1-3 4"></path>
+                </svg>
+              </span>
+              <h3>Brand Management</h3>
+              <p>
+                Markenführung bedeutet, Profil zu zeigen – klar, konsequent und mit Substanz. Ich begleite Marken mit
+                unternehmerischem Blick und helfe dabei, sie zu schärfen, zu positionieren und gezielt weiterzuentwickeln. Dazu
+                gehört auch, wie sie in Partnerschaften, Kooperationen oder gemeinsamen Auftritten souverän und unverwechselbar
+                bleiben. Ob Aufbau, Neuausrichtung oder Weiterführung: Ich unterstütze Marken dabei, aus ihrer Haltung heraus zu
+                führen – sichtbar, wirksam und eigenständig.
+              </p>
+            </article>
+            <article class="hb-card">
+              <span class="hb-card-icon">
+                <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+                  <circle cx="13.5" cy="6.5" r=".5"></circle>
+                  <circle cx="17.5" cy="10.5" r=".5"></circle>
+                  <circle cx="8.5" cy="7.5" r=".5"></circle>
+                  <circle cx="6.5" cy="12.5" r=".5"></circle>
+                  <path
+                    d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z"
+                  ></path>
+                </svg>
+              </span>
+              <h3>Brand Design</h3>
+              <p>
+                Ich entwickle präzise Designsysteme, die Markenwerte klar kommunizieren und konsistent in allen Kanälen
+                funktionieren. Durch modulare Strukturen, flexible Komponenten und klare Typologien entstehen Lösungen, die sich
+                gezielt an unterschiedliche Anforderungen anpassen lassen und langfristig die Marke stärken. Design wird damit
+                zum Werkzeug für Orientierung, Differenzierung und den Markenwert, der zum Erfolg führt.
+              </p>
+            </article>
+            <article class="hb-card">
+              <span class="hb-card-icon">
+                <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+                  <path
+                    d="M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z"
+                  ></path>
+                </svg>
+              </span>
+              <h3>KI - Workflow</h3>
+              <p>
+                Die Kombination aus Markenverständnis, Designkompetenz und KI-Know-how eröffnet neue Möglichkeiten. Ich
+                unterstütze Sie dabei, in kürzester Zeit funktionsfähige Prototypen und visuelle Konzepte zu erstellen – oft
+                parallel zur Briefingphase. Statt nur Prozesse zu steuern, setze ich operative Schritte direkt um und ermögliche
+                fundierte Entscheidungen bereits vor dem klassischen Produktionsstart. So verkürzt sich der Weg zur Umsetzung
+                signifikant – mit klaren Vorteilen in Tempo, Effizienz und Wirkung Ihrer Markenkommunikation.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="works" aria-labelledby="works-title" class="section-muted">
+        <div class="hb-container stack-xl" data-reveal>
+          <div class="works-intro">
+            <div class="stack-lg">
+              <h2 class="text-left">Portfolio &amp; Projekte</h2>
+              <p class="max-w-reading text-left">
+                Der Auszug zeigt, wie ich Markenführung und Design in konkreten Projekten zusammenbringe. Über „Portfolio
+                Insight“ stelle ich vertiefende Informationen zu Hintergründen, Abläufen und Entscheidungen bereit – auf Wunsch
+                auch im direkten Austausch.
+              </p>
+            </div>
+            <div class="stack-lg">
+              <h3 class="text-left">Strategie sichtbar machen. Wirkung beweisen.</h3>
+              <p class="max-w-reading text-left">
+                Markenarbeit bedeutet, Vision und Umsetzung zusammenzuführen. Jeder Case verbindet Strategie, Gestaltung und
+                KI-gestützte Workflows zu greifbaren Ergebnissen, die Marken stärken und Wachstum beschleunigen.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="action-slider" aria-label="Projekt-Slider">
+        <div class="hb-container" data-reveal>
+          <div
+            class="works-carousel"
+            data-carousel
+            data-auto-interval="7000"
+            role="region"
+            aria-roledescription="carousel"
+            aria-live="polite"
+          >
+            <div class="carousel-track" data-carousel-track>
+              <article class="carousel-slide" data-carousel-slide>
+                <div class="carousel-media">
+                  <img src="../img/main/hendrik_bogner_2.webp" alt="3D Rendering von smartSleep Produkt" loading="lazy" />
+                </div>
+                <div class="carousel-body">
+                  <h3>3D Design &amp; Renderings</h3>
+                  <p>
+                    Durch die Verwendung von 3D-Renderings anstelle aufwendiger Shootings lassen sich Zeit und Kosten bei der
+                    Erstellung von Produktabbildungen einsparen.
+                  </p>
+                  <a
+                    class="hb-cta is-secondary"
+                    href="https://hendrikbogner.myportfolio.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >Zu den Insights</a
+                  >
+                </div>
+              </article>
+
+              <article class="carousel-slide" data-carousel-slide>
+                <div class="carousel-media">
+                  <img src="../img/main/hendrik_bogner_p_launch.webp" alt="Launchkampagne smartsleep" loading="lazy" />
+                </div>
+                <div class="carousel-body">
+                  <h3>Teamzuwachs</h3>
+                  <p>
+                    Die Einführung von Smartsleep Immune und Smartsleep Beauty war ein wichtiger Schritt in der Erweiterung der
+                    Produktpalette. Die zwei Newcomer haben sich schnell als Erfolg erwiesen und bereichern das Markenportfolio –
+                    angepasst an die Bedürfnisse der Kunden und Fan-Base.
+                  </p>
+                  <a
+                    class="hb-cta is-secondary"
+                    href="https://hendrikbogner.myportfolio.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >Zu den Insights</a
+                  >
+                </div>
+              </article>
+
+              <article class="carousel-slide" data-carousel-slide>
+                <div class="carousel-media">
+                  <img src="../img/main/hendrik_bogner_out_of_home.webp" alt="Out-of-home Kampagne" loading="lazy" />
+                </div>
+                <div class="carousel-body">
+                  <h3>Big Citylight ...</h3>
+                  <p>Aufwachen? Mit Vergnügen!</p>
+                  <a
+                    class="hb-cta is-secondary"
+                    href="https://hendrikbogner.myportfolio.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >Zu den Insights</a
+                  >
+                </div>
+              </article>
+
+              <article class="carousel-slide" data-carousel-slide data-has-video>
+                <div class="carousel-media">
+                  <video
+                    src="../video/infotain_kreatin.mp4"
+                    muted
+                    playsinline
+                    preload="none"
+                    data-carousel-media
+                    aria-label="Animation zu Produktfragen"
+                  ></video>
+                </div>
+                <div class="carousel-body">
+                  <h3>Quick &amp; Easy</h3>
+                  <p>
+                    Antworten auf Fragen zur Produkteinführung: Eine FAQ-Kampagne adressiert Kundenfragen mit Animationen. Für
+                    jedes der drei Produkte entstanden zwölf Antworten – insgesamt 36 Animationen, die die Produktmerkmale
+                    erlebbar machen.
+                  </p>
+                  <a
+                    class="hb-cta is-secondary"
+                    href="https://hendrikbogner.myportfolio.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >Zu den Insights</a
+                  >
+                </div>
+              </article>
+
+              <article class="carousel-slide" data-carousel-slide data-has-video>
+                <div class="carousel-media">
+                  <video
+                    src="../video/infotain_vita.mp4"
+                    muted
+                    playsinline
+                    preload="none"
+                    data-carousel-media
+                    aria-label="Produktanimation Vita"
+                  ></video>
+                </div>
+                <div class="carousel-body">
+                  <h3>Quick &amp; Easy</h3>
+                  <p>
+                    Die Animationsvideos bieten eine schnelle und informative Möglichkeit, die gelaunchten Produkte vorzustellen
+                    und sie anhand der Produktvorteile voneinander zu unterscheiden.
+                  </p>
+                  <a
+                    class="hb-cta is-secondary"
+                    href="https://hendrikbogner.myportfolio.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >Zu den Insights</a
+                  >
+                </div>
+              </article>
+
+              <article class="carousel-slide" data-carousel-slide data-has-video>
+                <div class="carousel-media">
+                  <video
+                    src="../video/infotain_kollagen.mp4"
+                    muted
+                    playsinline
+                    preload="none"
+                    data-carousel-media
+                    aria-label="Produktanimation Beauty"
+                  ></video>
+                </div>
+                <div class="carousel-body">
+                  <h3>Quick &amp; Easy</h3>
+                  <p>
+                    FAQs in spannender Erzählform stärken das Markenimage und die Fan-Base in den Social-Media-Kanälen.
+                  </p>
+                  <a
+                    class="hb-cta is-secondary"
+                    href="https://hendrikbogner.myportfolio.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >Zu den Insights</a
+                  >
+                </div>
+              </article>
+
+              <article class="carousel-slide" data-carousel-slide>
+                <div class="carousel-media">
+                  <img src="../img/main/40.webp" alt="Out-of-Home Plakatkampagne" loading="lazy" />
+                </div>
+                <div class="carousel-body">
+                  <h3>Out Of Home</h3>
+                  <p>
+                    Die deutschlandweite Plakat-Kampagne wurde von einem Mega Blow Up in Hamburg gekrönt.
+                  </p>
+                  <a
+                    class="hb-cta is-secondary"
+                    href="https://hendrikbogner.myportfolio.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >Zu den Insights</a
+                  >
+                </div>
+              </article>
+
+              <article class="carousel-slide" data-carousel-slide>
+                <div class="carousel-media">
+                  <img src="../img/main/hendrik_bogner_hella_master_of_work.webp" alt="Hella Promo Video" loading="lazy" />
+                </div>
+                <div class="carousel-body">
+                  <h3>Promo Video</h3>
+                  <p>
+                    Wer sind die Coolsten im ganzen Land? Der internationale Automobilzulieferer Hella wollte es wissen – mit
+                    einem dynamischen Promo-Spot.
+                  </p>
+                  <a
+                    class="hb-cta is-secondary"
+                    href="https://hendrikbogner.myportfolio.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >Zu den Insights</a
+                  >
+                </div>
+              </article>
+            </div>
+
+            <div class="carousel-controls" aria-hidden="true">
+              <button class="carousel-button" type="button" data-carousel-prev aria-label="Vorheriger Slide">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+                  <path d="M15 18l-6-6 6-6" />
+                </svg>
+              </button>
+              <button class="carousel-button" type="button" data-carousel-next aria-label="Nächster Slide">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+                  <path d="M9 6l6 6-6 6" />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="vision1" class="section-muted" aria-labelledby="vision1-title">
+        <div class="hb-container stack-xl" data-reveal>
+          <h2 id="vision1-title" class="text-left">Vision &amp; Konzept von</h2>
+          <div class="braind-mark" aria-hidden="true">
+            <span>BR</span><span class="accent">A</span><span class="accent-alt">AI</span><span>ND</span>
+          </div>
+          <p class="max-w-reading text-left">
+            Als zertifizierter International Brand Manager, ausgebildeter Mediendesigner und KI-Spezialist verbinde ich die drei
+            Disziplinen, die die Arbeit bei der Entwicklung und Weiterentwicklung der Markenwerte effizienter und erfolgreicher
+            machen.
+          </p>
+        </div>
+      </section>
+
+      <section id="vision2" class="section-muted" aria-labelledby="vision2-title">
+        <span class="chapter-number" aria-hidden="true">1</span>
+        <div class="hb-container vision-shell" data-reveal>
+          <h2 id="vision2-title" class="vision-title">
+            <span class="accent-blue">Brand</span><span class="accent-navy">Strategy</span>
+          </h2>
+          <h3 class="text-left">Brand Manager als Kurator datengetriebener Markenführung</h3>
+          <p>
+            Moderne Markenstrategie findet im Spannungsfeld von Technologie, Geschwindigkeit und Komplexität statt. Künstliche
+            Intelligenz verändert dabei nicht nur das Werkzeugset – sie verschiebt die Logik. In Design und KI arbeite ich mit
+            einem erweiterten strategischen Verständnis. Im Rahmen meiner wissenschaftlichen Arbeit habe ich mich intensiv mit
+            datengetriebener Hyperpersonalisierung und ihrem Potenzial im internationalen Marketing beschäftigt – ein Feld, das
+            strategische Position permanent überprüft. Gleichzeitig wird Markenkonsistenz zur Herausforderung – denn
+            Personalisierung darf nicht zur Beliebigkeit führen. Es geht nicht mehr um einmal definierte Leitbilder, sondern um
+            ein klares Verständnis für den Unterschied zwischen Output und Wirkung.
+          </p>
+        </div>
+      </section>
+
+      <section id="vision3" class="section-muted" aria-labelledby="vision3-title">
+        <span class="chapter-number" aria-hidden="true">2</span>
+        <div class="hb-container vision-shell" data-reveal>
+          <h2 id="vision3-title" class="vision-title">
+            <span class="accent-navy">Brand</span><span class="accent-blue">Design</span>
+          </h2>
+          <h3 class="text-left">Visuelle Systeme neu denken – Design als skalierbare Infrastruktur</h3>
+          <p>
+            Künstliche Intelligenz verändert die Art, wie Design entsteht, verteilt und genutzt wird. Brand Design wird dadurch
+            nicht ersetzt, sondern neu organisiert. Statt einzelner Layouts entstehen flexible Systeme: visuelle Frameworks, die
+            skalierbar, adaptiv und konsistent sind – über alle Kanäle hinweg. Design wird zur Infrastruktur, die nicht nur Form,
+            sondern Funktion hat: Templates, Komponentenbibliotheken, Bildwelten und Typografie-Regeln lassen sich intelligent
+            verknüpfen, versionieren und automatisieren. KI-gestützte Tools unterstützen bei der Generierung, Variation und
+            Bewertung visueller Inhalte – von Midjourney über Runway bis zu dynamischen DAM-Systemen.
+          </p>
+        </div>
+      </section>
+
+      <section id="vision4" class="section-muted" aria-labelledby="vision4-title">
+        <span class="chapter-number" aria-hidden="true">3</span>
+        <div class="hb-container vision-shell" data-reveal>
+          <h2 id="vision4-title" class="vision-title">
+            <span class="accent-gradient">KI - Workflow</span>
+          </h2>
+          <h3 class="text-left">Von der Idee zur Umsetzung – neue Geschwindigkeit und neue Teamarbeit</h3>
+          <p>
+            KI verändert nicht nur das Werkzeug, sondern die Logik des Arbeitens. Klassisch lineare Prozesse – Briefing, Konzept,
+            Umsetzung, Korrektur – werden durch Parallelität, Automatisierung und Interaktion mit KI neu strukturiert. Das
+            beschleunigt nicht nur die Produktion, sondern transformiert ganze Arbeitsweisen. T-Shaped Professionals verbinden
+            Strategie, Design und Technologie, formulieren Use Cases, realisieren Prototypen und stellen Entscheidungsgrundlagen
+            schneller bereit. Teams brauchen Strukturen, in denen KI nicht bloß Effizienzfaktor, sondern echter
+            Produktivitätsgewinn ist.
+          </p>
+        </div>
+      </section>
+
+      <section id="vision5" class="section-muted" aria-labelledby="vision5-title">
+        <div class="hb-container vision-shell" data-reveal>
+          <h2 id="vision5-title" class="vision-title">
+            <span class="accent-blue">Connect</span><span class="accent-navy">The</span><span class="accent-gradient">Dots</span>
+          </h2>
+          <h3 class="text-left">Technologie als Werkzeug. Marke als Konstante.</h3>
+          <p>
+            So groß die Potenziale der Künstlichen Intelligenz auch sind – sie bleibt Mittel zum Zweck. Markenarbeit braucht
+            Haltung, Kontext und Erfahrung. KI ist ein Verstärker, kein Ersatz. Ihre Wirkung entsteht erst dann, wenn sie mit
+            strategischem Denken, gestalterischem Anspruch und unternehmerischem Verständnis verbunden wird. Die Herausforderung
+            liegt darin – und ist sogar ein Wettbewerbsvorteil –, das Beste aus beiden Welten zu verbinden: die Effizienz,
+            Geschwindigkeit und Tiefe der KI mit der Klarheit, Intuition und kulturellen Relevanz klassischer Markenführung.
+          </p>
+        </div>
+      </section>
+
+      <section id="partners" aria-labelledby="partners-title">
+        <div class="hb-container stack-xl" data-reveal>
+          <h2 id="partners-title" class="sr-only">Partner</h2>
+          <div class="partner-marquee">
+            <div class="partner-track" data-partner-track>
+              <img src="../img/kunden/1.png" alt="" />
+              <img src="../img/kunden/aldi3.png" alt="" />
+              <img src="../img/kunden/3.png" alt="" />
+              <img src="../img/kunden/SHOP.svg" alt="" />
+              <img src="../img/kunden/5.png" alt="" />
+              <img src="../img/kunden/6.png" alt="" />
+              <img src="../img/kunden/web_smartsleep_original_logo.svg" alt="" />
+              <img src="../img/kunden/TEDi-Logo.webp" alt="" />
+              <img src="../img/kunden/9.png" alt="" />
+              <img src="../img/kunden/Samsung.svg" alt="" />
+              <img src="../img/kunden/droege.png" alt="" />
+              <img src="../img/kunden/RWE_Logo_2020.svg" alt="" />
+              <img src="../img/kunden/Telekom_Logo.svg" alt="" />
+              <!-- Duplicate for seamless loop -->
+              <img src="../img/kunden/1.png" alt="" aria-hidden="true" />
+              <img src="../img/kunden/aldi3.png" alt="" aria-hidden="true" />
+              <img src="../img/kunden/3.png" alt="" aria-hidden="true" />
+              <img src="../img/kunden/SHOP.svg" alt="" aria-hidden="true" />
+              <img src="../img/kunden/5.png" alt="" aria-hidden="true" />
+              <img src="../img/kunden/6.png" alt="" aria-hidden="true" />
+              <img src="../img/kunden/web_smartsleep_original_logo.svg" alt="" aria-hidden="true" />
+              <img src="../img/kunden/TEDi-Logo.webp" alt="" aria-hidden="true" />
+              <img src="../img/kunden/9.png" alt="" aria-hidden="true" />
+              <img src="../img/kunden/Samsung.svg" alt="" aria-hidden="true" />
+              <img src="../img/kunden/droege.png" alt="" aria-hidden="true" />
+              <img src="../img/kunden/RWE_Logo_2020.svg" alt="" aria-hidden="true" />
+              <img src="../img/kunden/Telekom_Logo.svg" alt="" aria-hidden="true" />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="Kontakt" aria-labelledby="kontakt-title">
+        <div class="hb-container contact-shell" data-reveal>
+          <div class="stack-lg">
+            <h2 id="kontakt-title" class="text-left">
+              Auf der Suche nach einem großen Gedanken, der Unternehmen inspiriert und Kunden fasziniert?
+            </h2>
+            <p class="max-w-reading">
+              Kontaktieren Sie mich auf LinkedIn und lassen Sie uns gemeinsam Ihre nächsten Erfolge gestalten.
+            </p>
+            <div class="social-buttons" role="group" aria-label="Kontaktlinks">
+              <a
+                class="social-btn is-primary"
+                href="https://www.linkedin.com/in/hendrik-bogner/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <svg class="w-4 h-4" viewBox="0 0 448 512" fill="currentColor" aria-hidden="true">
+                  <path
+                    d="M100.28 448H7.4V148.9h92.88zm-46.44-340A53.86 53.86 0 1 1 107.7 54.24 53.86 53.86 0 0 1 53.84 108zm394.16 340h-92.4V302.4c0-34.7-.7-79.3-48.33-79.3-48.34 0-55.74 37.7-55.74 76.5V448h-92.6V148.9H242v40.8h1.3c12.9-24.4 44.3-50.1 91.2-50.1 97.5 0 115.5 64.2 115.5 147.5z"
+                  />
+                </svg>
+                LinkedIn
+              </a>
+              <a
+                class="social-btn is-outline"
+                href="https://www.youtube.com/channel/UCsoqDeIj5ORMRD0Wq_PRk-Q"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <svg class="w-4 h-4" viewBox="0 0 576 512" fill="currentColor" aria-hidden="true">
+                  <path
+                    d="M549.65 124.08a68.77 68.77 0 0 0-48.53-48.64C458.67 64 288 64 288 64S117.33 64 74.88 75.44a68.77 68.77 0 0 0-48.53 48.64C16 166.74 16 256 16 256s0 89.26 10.35 131.92a68.77 68.77 0 0 0 48.53 48.64C117.33 448 288 448 288 448s170.67 0 213.12-11.44a68.77 68.77 0 0 0 48.53-48.64C560 345.26 560 256 560 256s0-89.26-10.35-131.92ZM232 334V178l142 78Z"
+                  />
+                </svg>
+                YouTube
+              </a>
+            </div>
+          </div>
+          <div class="bulb-hero" aria-hidden="true">
+            <img src="../img/bulb_web.png" alt="Glühbirnen-Visual" loading="lazy" />
+            <div class="bulb-glow"></div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer" role="contentinfo">
+      <div class="hb-container footer-bar">
+        <div class="footer-brand">
+          <img src="../img/main/braind_logo_und_claim.svg" alt="BRAiND" />
+          <span>© 2025 Hendrik Bogner</span>
+        </div>
+        <nav class="footer-links" aria-label="Social Media">
+          <a href="https://www.linkedin.com/in/hendrik-bogner/" target="_blank" rel="noopener noreferrer">
+            <span class="sr-only">LinkedIn</span>
+            <svg class="w-5 h-5" viewBox="0 0 448 512" fill="currentColor" aria-hidden="true">
+              <path
+                d="M100.28 448H7.4V148.9h92.88zm-46.44-340A53.86 53.86 0 1 1 107.7 54.24 53.86 53.86 0 0 1 53.84 108zm394.16 340h-92.4V302.4c0-34.7-.7-79.3-48.33-79.3-48.34 0-55.74 37.7-55.74 76.5V448h-92.6V148.9H242v40.8h1.3c12.9-24.4 44.3-50.1 91.2-50.1 97.5 0 115.5 64.2 115.5 147.5z"
+              />
+            </svg>
+          </a>
+          <a href="https://www.youtube.com/channel/UCsoqDeIj5ORMRD0Wq_PRk-Q" target="_blank" rel="noopener noreferrer">
+            <span class="sr-only">YouTube</span>
+            <svg class="w-5 h-5" viewBox="0 0 576 512" fill="currentColor" aria-hidden="true">
+              <path
+                d="M549.65 124.08a68.77 68.77 0 0 0-48.53-48.64C458.67 64 288 64 288 64S117.33 64 74.88 75.44a68.77 68.77 0 0 0-48.53 48.64C16 166.74 16 256 16 256s0 89.26 10.35 131.92a68.77 68.77 0 0 0 48.53 48.64C117.33 448 288 448 288 448s170.67 0 213.12-11.44a68.77 68.77 0 0 0 48.53-48.64C560 345.26 560 256 560 256s0-89.26-10.35-131.92ZM232 334V178l142 78Z"
+              />
+            </svg>
+          </a>
+        </nav>
+      </div>
+    </footer>
+
+    <a class="top-link" href="#page-top" aria-label="Nach oben" data-back-to-top>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+        <path d="M12 5l7 7M12 5L5 12" />
+        <path d="M12 5v14" />
+      </svg>
+    </a>
+
+    <script src="./00_main_rebuilt.js" type="module"></script>
+  </body>
+</html>

--- a/004_packdat/z_Rebuild/00_main_rebuilt.js
+++ b/004_packdat/z_Rebuild/00_main_rebuilt.js
@@ -1,0 +1,307 @@
+const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+const isReducedMotion = () => prefersReducedMotion.matches;
+
+const clampIndex = (value, length) => {
+  const normalized = ((value % length) + length) % length;
+  return normalized;
+};
+
+const smoothScrollTo = (target, offset = 0) => {
+  if (!target) return;
+  const top = target.getBoundingClientRect().top + window.scrollY - offset;
+  window.scrollTo({ top, behavior: isReducedMotion() ? 'auto' : 'smooth' });
+};
+
+const initNavigation = () => {
+  const header = document.querySelector('[data-site-header]');
+  const toggle = document.querySelector('[data-nav-toggle]');
+  const panel = document.querySelector('[data-nav-panel]');
+  const backdrop = document.querySelector('[data-nav-backdrop]');
+  const inlineLinks = document.querySelectorAll('.nav-inline a[href^="#"]');
+  const panelLinks = panel ? panel.querySelectorAll('a[href^="#"]') : [];
+  let isOpen = false;
+
+  const getHeaderHeight = () => (header ? header.offsetHeight : 0);
+
+  const setState = (open) => {
+    isOpen = open;
+    if (panel) {
+      panel.setAttribute('data-open', open ? 'true' : 'false');
+      panel.setAttribute('aria-hidden', open ? 'false' : 'true');
+    }
+    if (toggle) {
+      toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+    if (header) {
+      header.classList.toggle('is-nav-open', open);
+    }
+  };
+
+  const closeNav = () => setState(false);
+
+  const handleLink = (event, hash) => {
+    const target = document.querySelector(hash);
+    if (target) {
+      event.preventDefault();
+      closeNav();
+      window.requestAnimationFrame(() => smoothScrollTo(target, getHeaderHeight() + 12));
+    }
+  };
+
+  inlineLinks.forEach((link) => {
+    const hash = link.getAttribute('href');
+    if (!hash || hash.length <= 1) return;
+    link.addEventListener('click', (event) => handleLink(event, hash));
+  });
+
+  panelLinks.forEach((link) => {
+    const hash = link.getAttribute('href');
+    if (!hash || hash.length <= 1) return;
+    link.addEventListener('click', (event) => handleLink(event, hash));
+  });
+
+  if (toggle) {
+    toggle.addEventListener('click', () => setState(!isOpen));
+  }
+
+  if (backdrop) {
+    backdrop.addEventListener('click', closeNav);
+  }
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && isOpen) {
+      closeNav();
+    }
+  });
+
+  window.addEventListener('resize', () => {
+    if (window.innerWidth >= 1024) {
+      closeNav();
+    }
+  });
+
+  const handleScroll = () => {
+    const scrolled = window.scrollY > 32;
+    if (header) {
+      header.classList.toggle('is-scrolled', scrolled);
+    }
+  };
+
+  window.addEventListener('scroll', handleScroll, { passive: true });
+  handleScroll();
+
+  return getHeaderHeight;
+};
+
+const initReveals = () => {
+  const revealElements = document.querySelectorAll('[data-reveal]');
+  if (!revealElements.length) return;
+
+  if ('IntersectionObserver' in window) {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('is-visible');
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.2 }
+    );
+
+    revealElements.forEach((el) => observer.observe(el));
+  } else {
+    revealElements.forEach((el) => el.classList.add('is-visible'));
+  }
+};
+
+const initCarousel = () => {
+  const carousel = document.querySelector('[data-carousel]');
+  if (!carousel) return;
+
+  const track = carousel.querySelector('[data-carousel-track]');
+  const slides = Array.from(track?.children || []);
+  const prevButton = carousel.querySelector('[data-carousel-prev]');
+  const nextButton = carousel.querySelector('[data-carousel-next]');
+  const autoInterval = Number(carousel.getAttribute('data-auto-interval')) || 7000;
+  let activeIndex = 0;
+  let autoTimer = null;
+
+  const updateMediaState = () => {
+    slides.forEach((slide, index) => {
+      const videos = slide.querySelectorAll('video');
+      videos.forEach((video) => {
+        if (index === activeIndex) {
+          if (!isReducedMotion()) {
+            video.play().catch(() => {});
+          }
+        } else {
+          video.pause();
+          if (!video.hasAttribute('data-preserve-time')) {
+            video.currentTime = 0;
+          }
+        }
+      });
+    });
+  };
+
+  const render = () => {
+    if (!track) return;
+    track.style.transform = `translateX(-${activeIndex * 100}%)`;
+    slides.forEach((slide, index) => {
+      slide.classList.toggle('is-active', index === activeIndex);
+    });
+    updateMediaState();
+  };
+
+  const goTo = (index) => {
+    if (!slides.length) return;
+    activeIndex = clampIndex(index, slides.length);
+    render();
+  };
+
+  const next = () => goTo(activeIndex + 1);
+  const prev = () => goTo(activeIndex - 1);
+
+  const stopAuto = () => {
+    if (autoTimer) {
+      window.clearInterval(autoTimer);
+      autoTimer = null;
+    }
+  };
+
+  const startAuto = () => {
+    stopAuto();
+    if (isReducedMotion()) return;
+    autoTimer = window.setInterval(next, autoInterval);
+  };
+
+  if (prevButton) {
+    prevButton.addEventListener('click', () => {
+      stopAuto();
+      prev();
+      startAuto();
+    });
+  }
+
+  if (nextButton) {
+    nextButton.addEventListener('click', () => {
+      stopAuto();
+      next();
+      startAuto();
+    });
+  }
+
+  carousel.addEventListener('pointerenter', stopAuto);
+  carousel.addEventListener('pointerleave', startAuto);
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) {
+      stopAuto();
+    } else {
+      startAuto();
+    }
+  });
+
+  prefersReducedMotion.addEventListener('change', () => {
+    if (isReducedMotion()) {
+      stopAuto();
+    } else {
+      startAuto();
+    }
+  });
+
+  render();
+  startAuto();
+};
+
+const initVideoTrigger = () => {
+  const wrappers = document.querySelectorAll('[data-video-trigger]');
+  wrappers.forEach((wrapper) => {
+    const id = wrapper.getAttribute('data-video-id');
+    if (!id) return;
+
+    const button = wrapper.querySelector('button');
+    const activate = () => {
+      const iframe = document.createElement('iframe');
+      iframe.src = `https://www.youtube.com/embed/${id}?autoplay=1&mute=1&rel=0`;
+      iframe.title = 'YouTube Video';
+      iframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share';
+      iframe.referrerPolicy = 'strict-origin-when-cross-origin';
+      iframe.allowFullscreen = true;
+      wrapper.replaceChildren(iframe);
+    };
+
+    if (button) {
+      button.addEventListener('click', activate);
+    }
+
+    wrapper.addEventListener('click', (event) => {
+      if (event.target === wrapper) {
+        activate();
+      }
+    });
+  });
+};
+
+const initTopLink = () => {
+  const topLink = document.querySelector('[data-back-to-top]');
+  if (!topLink) return;
+
+  const handleScroll = () => {
+    const threshold = window.innerHeight * 0.6;
+    if (window.scrollY > threshold) {
+      topLink.classList.add('is-visible');
+    } else {
+      topLink.classList.remove('is-visible');
+    }
+  };
+
+  window.addEventListener('scroll', handleScroll, { passive: true });
+  handleScroll();
+};
+
+const initPartnerMarquee = () => {
+  const track = document.querySelector('[data-partner-track]');
+  if (!track) return;
+
+  const applyMotionPreference = () => {
+    track.style.animationPlayState = isReducedMotion() ? 'paused' : 'running';
+  };
+
+  prefersReducedMotion.addEventListener('change', applyMotionPreference);
+  applyMotionPreference();
+};
+
+const initInternalAnchors = (getHeaderHeight) => {
+  const links = document.querySelectorAll('a[href^="#"]');
+  links.forEach((link) => {
+    const hash = link.getAttribute('href');
+    if (!hash || hash.length <= 1) return;
+    if (link.closest('[data-nav-panel]')) return;
+    if (link.closest('.nav-inline')) return;
+
+    link.addEventListener('click', (event) => {
+      const target = document.querySelector(hash);
+      if (!target) return;
+      const samePage = link.pathname === window.location.pathname;
+      if (!samePage) return;
+      event.preventDefault();
+      smoothScrollTo(target, (getHeaderHeight ? getHeaderHeight() : 0) + 12);
+    });
+  });
+};
+
+const boot = () => {
+  const getHeaderHeight = initNavigation();
+  initReveals();
+  initCarousel();
+  initVideoTrigger();
+  initTopLink();
+  initPartnerMarquee();
+  initInternalAnchors(getHeaderHeight);
+};
+
+document.addEventListener('DOMContentLoaded', boot);

--- a/004_packdat/z_Rebuild/00_main_rebuilt.js
+++ b/004_packdat/z_Rebuild/00_main_rebuilt.js
@@ -14,78 +14,27 @@ const smoothScrollTo = (target, offset = 0) => {
 };
 
 const initNavigation = () => {
-  const header = document.querySelector('[data-site-header]');
-  const toggle = document.querySelector('[data-nav-toggle]');
-  const panel = document.querySelector('[data-nav-panel]');
-  const backdrop = document.querySelector('[data-nav-backdrop]');
-  const inlineLinks = document.querySelectorAll('.nav-inline a[href^="#"]');
-  const panelLinks = panel ? panel.querySelectorAll('a[href^="#"]') : [];
-  let isOpen = false;
+  const header = document.querySelector('#nav-main');
+  const navLinks = header ? header.querySelectorAll('a[href^="#"]') : [];
 
   const getHeaderHeight = () => (header ? header.offsetHeight : 0);
 
-  const setState = (open) => {
-    isOpen = open;
-    if (panel) {
-      panel.setAttribute('data-open', open ? 'true' : 'false');
-      panel.setAttribute('aria-hidden', open ? 'false' : 'true');
-    }
-    if (toggle) {
-      toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
-    }
-    if (header) {
-      header.classList.toggle('is-nav-open', open);
-    }
-  };
-
-  const closeNav = () => setState(false);
-
   const handleLink = (event, hash) => {
     const target = document.querySelector(hash);
-    if (target) {
-      event.preventDefault();
-      closeNav();
-      window.requestAnimationFrame(() => smoothScrollTo(target, getHeaderHeight() + 12));
-    }
+    if (!target) return;
+    event.preventDefault();
+    window.requestAnimationFrame(() => smoothScrollTo(target, getHeaderHeight() + 12));
   };
 
-  inlineLinks.forEach((link) => {
+  navLinks.forEach((link) => {
     const hash = link.getAttribute('href');
     if (!hash || hash.length <= 1) return;
     link.addEventListener('click', (event) => handleLink(event, hash));
-  });
-
-  panelLinks.forEach((link) => {
-    const hash = link.getAttribute('href');
-    if (!hash || hash.length <= 1) return;
-    link.addEventListener('click', (event) => handleLink(event, hash));
-  });
-
-  if (toggle) {
-    toggle.addEventListener('click', () => setState(!isOpen));
-  }
-
-  if (backdrop) {
-    backdrop.addEventListener('click', closeNav);
-  }
-
-  document.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape' && isOpen) {
-      closeNav();
-    }
-  });
-
-  window.addEventListener('resize', () => {
-    if (window.innerWidth >= 1024) {
-      closeNav();
-    }
   });
 
   const handleScroll = () => {
-    const scrolled = window.scrollY > 32;
-    if (header) {
-      header.classList.toggle('is-scrolled', scrolled);
-    }
+    if (!header) return;
+    header.classList.toggle('is-scrolled', window.scrollY > 32);
   };
 
   window.addEventListener('scroll', handleScroll, { passive: true });

--- a/004_packdat/z_Rebuild/00_tailwind.config.js
+++ b/004_packdat/z_Rebuild/00_tailwind.config.js
@@ -1,0 +1,64 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./00_index_rebuilt.html', './00_main_rebuilt.js'],
+  theme: {
+    fontFamily: {
+      sans: ['Hanken Grotesk', 'Hanken', 'Inter', 'system-ui', '-apple-system', 'Segoe UI', 'sans-serif'],
+      display: ['Montserrat', 'Hanken Grotesk', 'Hanken', 'Inter', 'system-ui', '-apple-system', 'Segoe UI', 'sans-serif'],
+    },
+    extend: {
+      colors: {
+        'hb-bg': 'var(--hb-color-body)',
+        'hb-surface': 'var(--hb-color-surface)',
+        'hb-primary': 'var(--hb-color-primary)',
+        'hb-accent': 'var(--hb-color-accent)',
+        'hb-accent-alt': 'var(--hb-color-accent-alt)',
+        'hb-text': 'var(--hb-color-text)',
+      },
+      spacing: {
+        'fluid-1': 'var(--hb-space-1)',
+        'fluid-2': 'var(--hb-space-2)',
+        'fluid-3': 'var(--hb-space-3)',
+        'fluid-4': 'var(--hb-space-4)',
+        'fluid-5': 'var(--hb-space-5)',
+        'fluid-6': 'var(--hb-space-6)',
+        'fluid-7': 'var(--hb-space-7)',
+        'fluid-8': 'var(--hb-space-8)',
+        'fluid-9': 'var(--hb-space-9)',
+        'fluid-10': 'var(--hb-space-10)',
+        'fluid-11': 'var(--hb-space-11)',
+        'fluid-12': 'var(--hb-space-12)',
+      },
+      borderRadius: {
+        'hb-xs': 'var(--hb-radius-xs)',
+        'hb-sm': 'var(--hb-radius-sm)',
+        'hb-md': 'var(--hb-radius-md)',
+        'hb-lg': 'var(--hb-radius-lg)',
+        'hb-xl': 'var(--hb-radius-xl)',
+        'hb-pill': 'var(--hb-radius-pill)',
+      },
+      boxShadow: {
+        'hb-soft': 'var(--hb-shadow-soft)',
+        'hb-glass': 'var(--hb-shadow-glass)',
+        'hb-glow': 'var(--hb-shadow-glow)',
+      },
+      backgroundImage: {
+        'hb-hero': 'var(--hb-gradient-hero)',
+        'hb-panel': 'var(--hb-gradient-panel)',
+        'hb-footer': 'var(--hb-gradient-footer)',
+      },
+    },
+  },
+  corePlugins: {
+    preflight: false,
+  },
+  plugins: [
+    function ({ addUtilities }) {
+      addUtilities({
+        '.text-balance': {
+          'text-wrap': 'balance',
+        },
+      });
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- switch design tokens to the light palette defined by the reference image
- refresh base styles to use the new light surfaces, glass layers, and component treatments for navigation, cards, and controls

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690932aa56d08320913c05258fbf02bf