### PR TITLE
Add CI pink hover underline animation for navigation links

### DIFF
--- a/Codex_WORKSPACE/style.css
+++ b/Codex_WORKSPACE/style.css
@@ -222,13 +222,11 @@ header nav a.active:not(.cta-button)::after,
 }
 .hero-subline span{display:inline-block}
 .hero-main-headline {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
+  display: grid;
+  place-items: center;
   text-align: center;
   margin-inline: auto;
-  max-width: 60ch;
+  width: min(100%, 60ch);
   align-self: center;
   transform: translateY(0);
 }
@@ -238,8 +236,7 @@ header nav a.active:not(.cta-button)::after,
   margin:0;
   text-shadow:0 2px 10px rgba(0,0,0,.1);
   text-align:center;
-  max-width:60ch;
-  margin-inline:auto;
+  width:100%;
 }
 .hero-content-text{
   margin-top:var(--space-m);
@@ -257,7 +254,7 @@ header nav a.active:not(.cta-button)::after,
 
 @media (max-width: 360px){
   .hero-main-headline{
-    max-width:52ch;
+    width:min(100%, 52ch);
   }
 }
 .glass-card{

--- a/Codex_WORKSPACE/style.css
+++ b/Codex_WORKSPACE/style.css
@@ -21,6 +21,8 @@
   --color-bg-beige: #f5ece1;
   --color-bg-nav: rgba(255, 255, 255, 0.15);
 
+  --ci-pink: #ff3cd0;
+
   --gradient-primary: linear-gradient(135deg, #2d5eff 0%, #7d32df 50%, #ff4bc0 85%);
   --gradient-hero-bg: linear-gradient(135deg, #b5d4ff, #2d5eff);
   --gradient-text: linear-gradient(90deg, #207cfa, #ff00a9);
@@ -95,12 +97,67 @@ h2{font-size:clamp(2rem,4vw + 1rem,3.5rem)}
   font-weight:500;font-size:.9rem;text-transform:uppercase;letter-spacing:.05em;
   color:var(--color-text-primary);padding:var(--space-xs) 0;transition:color var(--transition-fast)
 }
-.nav-left a:hover,.nav-right a:not(.cta-button):hover{color:var(--color-blue)}
+.nav-left a:hover,
+.nav-left a:focus-visible,
+.nav-right a:not(.cta-button):hover,
+.nav-right a:not(.cta-button):focus-visible{color:var(--ci-pink)}
 .navbar-brand-center img{height:36px;filter:drop-shadow(0 2px 4px rgba(0,0,0,.1))}
 .nav-button{padding:.6em 1.5em;font-size:.85rem;box-shadow:0 4px 15px rgba(0,0,0,.1),var(--shadow-glow)}
 .navbar-toggle{display:none;background:none;border:none;cursor:pointer}
 .icon-bar{display:block;width:25px;height:3px;background-color:var(--color-text-primary);margin:5px 0}
 .mobile-nav{display:none}
+
+header nav a:not(.cta-button),
+.mobile-nav a:not(.cta-button){
+  position:relative;
+  text-decoration:none;
+  transition:color .2s ease;
+}
+
+header nav a:not(.cta-button)::after,
+.mobile-nav a:not(.cta-button)::after{
+  content:"";
+  position:absolute;
+  left:0;
+  bottom:-0.2em;
+  height:2px;
+  width:100%;
+  background:var(--ci-pink);
+  transform:scaleX(0);
+  transform-origin:left center;
+  transition:transform .25s ease;
+}
+
+header nav a:not(.cta-button):hover,
+header nav a:not(.cta-button):focus-visible,
+.mobile-nav a:not(.cta-button):hover,
+.mobile-nav a:not(.cta-button):focus-visible{
+  color:var(--ci-pink);
+}
+
+header nav a:not(.cta-button):hover::after,
+header nav a:not(.cta-button):focus-visible::after,
+.mobile-nav a:not(.cta-button):hover::after,
+.mobile-nav a:not(.cta-button):focus-visible::after{
+  transform:scaleX(1);
+}
+
+header nav a.active:not(.cta-button)::after,
+.mobile-nav a.active:not(.cta-button)::after{
+  transform:scaleX(1);
+}
+
+@media (prefers-reduced-motion:reduce){
+  header nav a:not(.cta-button),
+  .mobile-nav a:not(.cta-button){
+    transition:none;
+  }
+
+  header nav a:not(.cta-button)::after,
+  .mobile-nav a:not(.cta-button)::after{
+    transition:none;
+  }
+}
 
 /* 6) HERO */
 .hero-section{

--- a/Codex_WORKSPACE/style.css
+++ b/Codex_WORKSPACE/style.css
@@ -222,24 +222,24 @@ header nav a.active:not(.cta-button)::after,
 }
 .hero-subline span{display:inline-block}
 .hero-main-headline {
-  width: 100%;
-  max-width: 60ch;
-  margin-inline: auto;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   text-align: center;
+  margin-inline: auto;
+  max-width: 60ch;
+  align-self: center;
+  transform: translateY(0);
 }
 .hero-main-headline h2{
   font-size:clamp(2.8rem, 5.5vw, 4.5rem);
   font-weight:800;
-  margin-top:var(--space-xl);
+  margin:0;
   text-shadow:0 2px 10px rgba(0,0,0,.1);
   text-align:center;
   max-width:60ch;
   margin-inline:auto;
-  transform: translateY(-1.25rem);
 }
 .hero-content-text{
   margin-top:var(--space-m);

--- a/Codex_WORKSPACE/style.css
+++ b/Codex_WORKSPACE/style.css
@@ -222,13 +222,15 @@ header nav a.active:not(.cta-button)::after,
 }
 .hero-subline span{display:inline-block}
 .hero-main-headline {
-  display: grid;
-  place-items: center;
-  text-align: center;
-  margin-inline: auto;
-  width: min(100%, 60ch);
-  align-self: center;
-  transform: translateY(0);
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  justify-content:center;
+  text-align:center;
+  margin-inline:auto;
+  max-width:60ch;
+  align-self:center;
+  transform:translateY(0);
 }
 .hero-main-headline h2{
   font-size:clamp(2.8rem, 5.5vw, 4.5rem);
@@ -236,7 +238,6 @@ header nav a.active:not(.cta-button)::after,
   margin:0;
   text-shadow:0 2px 10px rgba(0,0,0,.1);
   text-align:center;
-  width:100%;
 }
 .hero-content-text{
   margin-top:var(--space-m);
@@ -254,7 +255,7 @@ header nav a.active:not(.cta-button)::after,
 
 @media (max-width: 360px){
   .hero-main-headline{
-    width:min(100%, 52ch);
+    max-width:52ch;
   }
 }
 .glass-card{

--- a/Codex_WORKSPACE/style.css
+++ b/Codex_WORKSPACE/style.css
@@ -28,6 +28,8 @@
   --gradient-text: linear-gradient(90deg, #207cfa, #ff00a9);
   --gradient-button: linear-gradient(105deg, var(--color-blue), var(--color-pink));
 
+  --hero-quote-mobile-offset: 1.875rem;
+
 
   --space-xs: 0.5rem;
   --space-s: 1rem;
@@ -221,16 +223,22 @@ header nav a.active:not(.cta-button)::after,
 .hero-subline span{display:inline-block}
 .hero-main-headline {
   width: 100%;
+  max-width: 60ch;
+  margin-inline: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
 }
 .hero-main-headline h2{
   font-size:clamp(2.8rem, 5.5vw, 4.5rem);
   font-weight:800;
   margin-top:var(--space-xl);
   text-shadow:0 2px 10px rgba(0,0,0,.1);
-  text-align:left;
-  max-width:1350px;
-  margin-left:auto;
-  margin-right:auto;
+  text-align:center;
+  max-width:60ch;
+  margin-inline:auto;
   transform: translateY(-1.25rem);
 }
 .hero-content-text{
@@ -240,6 +248,17 @@ header nav a.active:not(.cta-button)::after,
   margin-left:auto;
   margin-right:auto;
   transform: translateY(-1.25rem);
+}
+@media (max-width: 600px){
+  .hero-main-headline{
+    transform: translateY(calc(-1 * var(--hero-quote-mobile-offset)));
+  }
+}
+
+@media (max-width: 360px){
+  .hero-main-headline{
+    max-width:52ch;
+  }
 }
 .glass-card{
   background:rgba(255,255,255,.15);

--- a/Codex_WORKSPACE/style.css
+++ b/Codex_WORKSPACE/style.css
@@ -222,13 +222,11 @@ header nav a.active:not(.cta-button)::after,
 }
 .hero-subline span{display:inline-block}
 .hero-main-headline {
-  display:flex;
-  flex-direction:column;
-  align-items:center;
-  justify-content:center;
-  text-align:center;
+  display:grid;
+  place-items:center;
+  width:min(60ch, 100%);
   margin-inline:auto;
-  max-width:60ch;
+  text-align:center;
   align-self:center;
   transform:translateY(0);
 }
@@ -238,6 +236,7 @@ header nav a.active:not(.cta-button)::after,
   margin:0;
   text-shadow:0 2px 10px rgba(0,0,0,.1);
   text-align:center;
+  width:100%;
 }
 .hero-content-text{
   margin-top:var(--space-m);


### PR DESCRIPTION
## Summary
- add a CI pink design token for navigation link styling and update hover/focus color usage
- create animated underline pseudo-elements for desktop and mobile navigation links with reduced-motion support

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691208b46390832090d037c0850cd57c)